### PR TITLE
feat(component_jobs): trigger build on a push to component repo PR or master branch

### DIFF
--- a/jobs/component_jobs.groovy
+++ b/jobs/component_jobs.groovy
@@ -88,6 +88,10 @@ repos.each { Map repo ->
         }
       }
 
+      triggers {
+        githubPush()
+      }
+
       wrappers {
         timestamps()
         colorizeOutput 'xterm'


### PR DESCRIPTION
This adds a trigger to kick off a Jenkins build for a given `<component>(-pr)` job whenever a push occurs on the PR or master branch of that component, accordingly.
