### PR TITLE
chore(common): Only keep 10 builds

### DIFF
--- a/common.groovy
+++ b/common.groovy
@@ -19,7 +19,7 @@ repos.each { Map repo ->
 }
 
 defaults = [
-  numBuildsToKeep: 42,
+  numBuildsToKeep: 10,
   bumpverCommitCmd: 'git commit -a -m "chore(versions): ci bumped versions via ${BUILD_URL}" || true',
   testJob: [master: 'workflow-test', pr: 'workflow-test-pr'],
   maxBuildsPerNode: 1,


### PR DESCRIPTION
There is no reason to keep around 42 builds. 10 should be sufficient
