### PR TITLE
fix(workflow_test): slack messages now joined with newline

### DIFF
--- a/jobs/workflow_test.groovy
+++ b/jobs/workflow_test.groovy
@@ -14,7 +14,7 @@ evaluate(new File("${WORKSPACE}/common.groovy"))
   upstreamJobMsg = "Upstream job: ${JENKINS_URL}job/\${UPSTREAM_JOB_NAME}/\${UPSTREAM_BUILD_NUMBER}"
   slackConfig = [
     channel: isParallel ? defaults.slack['channel'] : '#${UPSTREAM_SLACK_CHANNEL}',
-    message: isParallel ? testReportMsg : testReportMsg + upstreamJobMsg,
+    message: isParallel ? testReportMsg : [testReportMsg, upstreamJobMsg].join('\n'),
   ]
 
   job(defaults.testJob[config.type]) {


### PR DESCRIPTION
Jenkins Slack notification message was malformed:

`Test Report: https://ci.deis.io/job/workflow-test-pr/305/testReportUpstream job: https://ci.deis.io/job/builder-pr/42`

This change now adds the necessary newline between `Test Report` and `Upstream job` messages.
