### PR TITLE
fix(workflow_test): remove hard-coded slack integration token

### DIFF
--- a/common.groovy
+++ b/common.groovy
@@ -27,7 +27,6 @@ defaults = [
   workflowChart: 'workflow-dev',
   slack: [
     teamDomain: 'deis',
-    integrationToken: 'bjgJFzVasJtMgP63KiYCfVPE',
     channel: '#testing',
   ],
 ]

--- a/jobs/workflow_test.groovy
+++ b/jobs/workflow_test.groovy
@@ -46,9 +46,12 @@ evaluate(new File("${WORKSPACE}/common.groovy"))
 
     publishers {
       slackNotifications {
-        teamDomain(defaults.slack['teamDomain'])
-        integrationToken(defaults.slack['integrationToken'])
-        projectChannel(slackConfig.channel)
+        // TODO: re-enable once integrationToken can make use of Jenkins'
+        // secure credentials handling:
+        // https://github.com/jenkinsci/slack-plugin/pull/208
+        // teamDomain(defaults.slack['teamDomain'])
+        // integrationToken('${SLACK_INTEGRATION_TOKEN}')
+        // projectChannel(slackConfig.channel)
         customMessage(slackConfig.message)
         notifyAborted()
         notifyFailure()


### PR DESCRIPTION
With plans to revisit once plugin supports secure credentials handling:
https://github.com/jenkinsci/slack-plugin/pull/208

Background on need for this functionality: https://github.com/jenkinsci/slack-plugin/issues/195

With this change, slack notifications will revert to using the global defaults (meaning will only be able to broadcast to the one default channel at this time.)

cc @Joshua-Anderson
