### PR TITLE
feat(workflow_test): make parallel test run the default

### DIFF
--- a/common.groovy
+++ b/common.groovy
@@ -21,7 +21,7 @@ repos.each { Map repo ->
 defaults = [
   numBuildsToKeep: 42,
   bumpverCommitCmd: 'git commit -a -m "chore(versions): ci bumped versions via ${BUILD_URL}" || true',
-  testJob: [master: 'workflow-test', pr: 'workflow-test-pr', parallel: 'workflow-test-parallel'],
+  testJob: [master: 'workflow-test', pr: 'workflow-test-pr'],
   maxBuildsPerNode: 1,
   maxTotalConcurrentBuilds: 3,
   workflowChart: 'workflow-dev',


### PR DESCRIPTION
This changes both `workflow-test` and `workflow-test-pr` jobs
to default to running the e2e tests in parallel.  (As of this writing
that means installing the `deis-tests-parallel` chart.)

To run tests sequentially in said jobs, set `PARALLEL_TESTS` to false.

Closes #17
