### PR TITLE
feat(component_jobs): this removes the use of the ghprb plugin

### DIFF
--- a/jobs/component_jobs.groovy
+++ b/jobs/component_jobs.groovy
@@ -47,31 +47,6 @@ repos.each { Map repo ->
         numToKeep defaults.numBuildsToKeep
       }
 
-      if (isPR) { // set up GitHubPullRequest build trigger
-        triggers {
-          pullRequest {
-            admin('deis-admin')
-            cron('H/5 * * * *')
-            useGitHubHooks()
-            triggerPhrase('OK to test')
-            orgWhitelist(['deis'])
-            allowMembersOfWhitelistedOrgsAsAdmin()
-            // this plugin will update PR status no matter what,
-            // so until we fix this, here are our default messages:
-            extensions {
-              commitStatus {
-                context('ci/jenkins/pr')
-                triggeredStatus("Triggering ${repo.name} build/deploy...")
-                startedStatus("Starting ${repo.name} build/deploy...")
-                completedStatus('SUCCESS', "Merge with caution! Test job(s) may still be in progress...")
-                completedStatus('FAILURE', 'Build/deploy returned failure(s).')
-                completedStatus('ERROR', 'Something went wrong.')
-              }
-            }
-          }
-        }
-      }
-
       if (isMaster) { // used for remote build trigger (from TravisCI)
         authenticationToken('5ISZbTayHuC0nHV')
       }


### PR DESCRIPTION
We only use this plugin for whitelisting PRs but I propose
although this utility prevents a theoretical issue, the plugin is
not something we should continue using if it is preventing our ideal
CI pipeline state (involving setting commit status messages outside
of what said plugin now overrides)
