### PR TITLE
fix(component_jobs): the commit needed to update GH PR status is ghprbActualCommit, not GIT_COMMIT

### DIFF
--- a/jobs/utilities/StatusUpdater.groovy
+++ b/jobs/utilities/StatusUpdater.groovy
@@ -12,7 +12,7 @@ class StatusUpdater {
         --data '{\
           "state":"${args.commitStatus}",\
           "target_url":"'"\${BUILD_URL}"'",\
-          "description":"${args.jobName} job ${args.buildStatus}, current status: ${args.commitStatus}",\
+          "description":"${args.description}",\
           "context":"ci/jenkins/pr"}'\
         "https://api.github.com/repos/deis/${args.repoName}/statuses/${args.commitSHA}"
     """.stripIndent().trim()


### PR DESCRIPTION
As the two are different, the previous status updates were going to the
wrong status endpoint (GIT_COMMIT, or local merge commit).  

This is now fixed, using the actual/initial commit SHA offered by the
ghprb plugin in the form of the 'ghprbActualCommit' env var.
