### PR TITLE
fix(workflow_test): allow empty junit results

### DIFF
--- a/jobs/workflow_test.groovy
+++ b/jobs/workflow_test.groovy
@@ -67,12 +67,14 @@ import utilities.StatusUpdater
 
        archiveJunit('logs/**/junit*.xml') {
          retainLongStdout(false)
+         allowEmptyResults()
        }
 
        archiveArtifacts {
          pattern('logs/${BUILD_NUMBER}/**')
          onlyIfSuccessful(false)
          fingerprint(false)
+         allowEmpty()
        }
 
        if (isPR) {


### PR DESCRIPTION
This prevents empty junit results failing CI, while we work on the fix to actually properly log all of the `junit-*.xml` files (see https://github.com/sgoings/chart-mate/pull/51).

This also allows empty artifact results.
