### PR TITLE
fix(workflow_test): increase test job timeout to 30 mins

### DIFF
--- a/jobs/workflow_test.groovy
+++ b/jobs/workflow_test.groovy
@@ -115,7 +115,9 @@ import utilities.StatusUpdater
 
     wrappers {
       timeout {
-        absolute(25)
+        // Revisit when https://github.com/deis/jenkins-jobs/issues/51 complete
+        // (timeout can/should be decreased)
+        absolute(30)
         failBuild()
       }
       timestamps()


### PR DESCRIPTION
I think our current timeout of 25 mins is slightly too aggressive at this point in time; see https://ci.deis.io/job/workflow-test-pr/757/console for an example.
