### PR TITLE
chore(all jobs): Increase kept builds to 14 days (one sprint)

### DIFF
--- a/common.groovy
+++ b/common.groovy
@@ -21,7 +21,7 @@ repos.each { Map repo ->
 TEST_JOB_ROOT_NAME = 'workflow-test'
 
 defaults = [
-  numBuildsToKeep: 42,
+  daysToKeep: 14,
   bumpverCommitCmd: 'git commit -a -m "chore(versions): ci bumped versions via ${BUILD_URL}" || true',
   testJob: [master: "${TEST_JOB_ROOT_NAME}", pr: "${TEST_JOB_ROOT_NAME}-pr"],
   maxBuildsPerNode: 1,

--- a/jobs/component_jobs.groovy
+++ b/jobs/component_jobs.groovy
@@ -44,7 +44,7 @@ repos.each { Map repo ->
       }
 
       logRotator {
-        numToKeep defaults.numBuildsToKeep
+        daysToKeep defaults.daysToKeep
       }
 
       if (isPR) { // set up GitHubPullRequest build trigger

--- a/jobs/workflow_test.groovy
+++ b/jobs/workflow_test.groovy
@@ -31,7 +31,7 @@ import utilities.StatusUpdater
     }
 
     logRotator {
-      numToKeep defaults.numBuildsToKeep
+      daysToKeep defaults.daysToKeep
     }
 
     if (isPR) {


### PR DESCRIPTION
All roads lead to this job... it's being run so many times a day that if you click "details" in your PR with the intention of examining or restarting a failed job, chances are quite high that failed execution has already rotated out of the kept builds.

**EDIT:**

~~This PR increases the number of kept builds, specifically for the `workflow-test-pr` job, from the default of 42 up to (an arbitrarily chosen and hopefully high enough) 250.~~

This PR makes jobs keep builds for 14 days-- which is the current length of a single sprint.  Unless we're running late, this should allow us to restart any job from the current spring up to the last day of that sprint.
