### PR TITLE
feat(jobs): add seed-repo job

### DIFF
--- a/jobs/seed_repos.groovy
+++ b/jobs/seed_repos.groovy
@@ -1,0 +1,53 @@
+evaluate(new File("${WORKSPACE}/common.groovy"))
+
+import utilities.StatusUpdater
+
+name = 'deis-seed-repos'
+repoName = 'seed-repo'
+
+job(name) {
+  description """
+    <p>Runs deis/seed-repo against all of the workflow components.</p>
+  """.stripIndent().trim()
+
+  scm {
+    git {
+      remote {
+        github("deis/${repoName}")
+      }
+      branch('master')
+    }
+  }
+
+  logRotator {
+    daysToKeep defaults.daysToKeep
+  }
+
+  triggers {
+    githubPush()
+  }
+
+  wrappers {
+    timeout {
+      absolute(defaults.testJob["timeoutMins"])
+      failBuild()
+    }
+    timestamps()
+    colorizeOutput 'xterm'
+    credentialsBinding {
+      string("GITHUB_ACCESS_TOKEN", "8e11254f-44f3-4ddd-bf98-2cabcb7434cd")
+    }
+  }
+
+  steps {
+    repos.each { Map repo ->
+      shell """
+      #!/usr/bin/env bash
+
+      set -eo pipefail
+
+      ./seed-repo deis/${repo.name}
+      """.stripIndent().trim()
+    }
+  }
+}

--- a/jobs/seed_repos.groovy
+++ b/jobs/seed_repos.groovy
@@ -36,14 +36,14 @@ job(name) {
   }
 
   steps {
-    repos.each { Map repo ->
-      shell """
-      #!/usr/bin/env bash
+    shell """
+    #!/usr/bin/env bash
 
-      set -eo pipefail
+    set -eo pipefail
 
-      ./seed-repo deis/${repo.name}
-      """.stripIndent().trim()
-    }
+    bundle install
+
+    for i in $(./list-repos); do ./seed-repo $i; done
+    """.stripIndent().trim()
   }
 }

--- a/jobs/seed_repos.groovy
+++ b/jobs/seed_repos.groovy
@@ -1,7 +1,5 @@
 evaluate(new File("${WORKSPACE}/common.groovy"))
 
-import utilities.StatusUpdater
-
 name = 'deis-seed-repos'
 repoName = 'seed-repo'
 

--- a/jobs/seed_repos.groovy
+++ b/jobs/seed_repos.groovy
@@ -28,10 +28,6 @@ job(name) {
   }
 
   wrappers {
-    timeout {
-      absolute(defaults.testJob["timeoutMins"])
-      failBuild()
-    }
     timestamps()
     colorizeOutput 'xterm'
     credentialsBinding {


### PR DESCRIPTION
This job will run deis/seed-repo against all of the workflow components on any merge to
deis/seed-repo. This allows all of our components to be kept up-to-date by making changes in one
place, and not having us to manually run this against all of our repositories.

This is my first PR against jenkins-jobs so please let me know if I messed something up. I verified this against the Jenkins Job DSL Playground and it generated the XML I desired (after directly importing common.groovy into the script and removing things like WORKSPACE and JENKINS_URL)

addresses #71
