### PR TITLE
fix(seed-repos): escape dollar signs in string

### DIFF
--- a/jobs/seed_repos.groovy
+++ b/jobs/seed_repos.groovy
@@ -41,7 +41,7 @@ job(name) {
 
     bundle install
 
-    for i in $(./list-repos); do ./seed-repo $i; done
+    for i in \$(./list-repos); do ./seed-repo \$i; done
     """.stripIndent().trim()
   }
 }


### PR DESCRIPTION
```
workspace://component-seed-job/jobs/seed_repos.groovy: 37: illegal string body character after dollar sign;
solution: either escape a literal dollar sign "\$5" or bracket the value expression "${5}" @ line 37, column 5.
```

followup of #74. You can see the failure at https://ci.deis.io/job/component-seed-job/52/console

:sheep: 
