### PR TITLE
chore(monitor): Remove inclusion check

### DIFF
--- a/jobs/monitor_jobs.groovy
+++ b/jobs/monitor_jobs.groovy
@@ -40,9 +40,11 @@ dirs.each { Map dir ->
             }
             branch(config.branch)
           }
-          configure { gitScm ->
-            gitScm / 'extensions' << 'hudson.plugins.git.extensions.impl.PathRestriction' {
-              includedRegions("${dir.name}/**")
+          if (!isPr) {
+            configure { gitScm ->
+              gitScm / 'extensions' << 'hudson.plugins.git.extensions.impl.PathRestriction' {
+                includedRegions("${dir.name}/**")
+              }
             }
           }
         }


### PR DESCRIPTION
The inclusion check doesnt work for the PR builder so lets remove it for PRs but keep it for master jobs
