### PR TITLE
ref(seed-repos): containerize seed-repo operation

### DIFF
--- a/jobs/seed_repos.groovy
+++ b/jobs/seed_repos.groovy
@@ -39,9 +39,7 @@ job(name) {
 
     set -eo pipefail
 
-    bundle install
-
-    for i in \$(./list-repos); do ./seed-repo \$i; done
+    docker run -v \$PWD:/app ruby:2.3.1 bash -c 'cd /app && bundle install && for i in \$(./list-repos); do ./seed-repo \$i; done'
     """.stripIndent().trim()
   }
 }


### PR DESCRIPTION
This allows the job to install and run seed-repos inside a container, allowing the job to have no
reliance on the host except for docker and bash.

closes #71 
closes https://github.com/deis/seed-repo/issues/14
