### PR TITLE
fix(seed-repos): inject GITHUB_ACCESS_TOKEN inside container

### DIFF
--- a/jobs/seed_repos.groovy
+++ b/jobs/seed_repos.groovy
@@ -39,7 +39,7 @@ job(name) {
 
     set -eo pipefail
 
-    docker run -v \$PWD:/app ruby:2.3.1 bash -c 'cd /app && bundle install && for i in \$(./list-repos); do ./seed-repo \$i; done'
+    docker run -v \$PWD:/app -e GITHUB_ACCESS_TOKEN ruby:2.3.1 bash -c 'cd /app && bundle install && for i in \$(./list-repos); do ./seed-repo \$i; done'
     """.stripIndent().trim()
   }
 }


### PR DESCRIPTION
From docker's documentation, if no '=' is provided, then that variable’s current value is passed
through to the container (i.e. $MYVAR1 from the host is set to $MYVAR1 in the container). We can
use this to inject GITHUB_ACCESS_TOKEN into the running container.

fixes #82 
