### PR TITLE
feat(jobs/component_jobs.groovy): support testing sibling commits

### DIFF
--- a/bash/Dockerfile
+++ b/bash/Dockerfile
@@ -1,0 +1,23 @@
+FROM gcr.io/google_containers/ubuntu-slim:0.3
+
+ENV BATS_VERSION 0.4.0
+
+RUN addgroup --gid 999 batsman
+RUN adduser --system \
+	--shell /bin/bash \
+	--disabled-password \
+	--gid 999 \
+	--uid 999 \
+	batsman
+
+RUN apt-get update -q \
+	&& apt-get install -y -q --no-install-recommends bash make curl ca-certificates \
+	&& curl -o "/tmp/v${BATS_VERSION}.tar.gz" -L \
+		"https://github.com/sstephenson/bats/archive/v${BATS_VERSION}.tar.gz" \
+	&& tar -x -z -f "/tmp/v${BATS_VERSION}.tar.gz" -C /tmp/ \
+	&& bash "/tmp/bats-${BATS_VERSION}/install.sh" /usr/local \
+	&& rm -rf /tmp/*
+
+USER batsman
+
+ENTRYPOINT ["/usr/local/bin/bats"]

--- a/bash/Makefile
+++ b/bash/Makefile
@@ -1,0 +1,12 @@
+TEST_CMD := --tap tests
+
+test:
+	bats ${TEST_CMD}
+
+docker-build:
+	docker build -t bats .
+
+docker-test: docker-build
+	docker run -v ${CURDIR}:/bash -w /bash bats ${TEST_CMD}
+
+.PHONY: test docker-test docker-build

--- a/bash/scripts/commit_description_parser.sh
+++ b/bash/scripts/commit_description_parser.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+main() {
+  envPropsFilepath="/dev/null"
+  if [ -n "${JENKINS_HOME}" ] && [ "${JOB_BASE_NAME}" != "jenkins-jobs" ]; then
+    envPropsFilepath="${WORKSPACE}/env.properties"
+  fi
+  parse-commit-description "${ghprbPullLongDescription}" >> "${envPropsFilepath}"
+}
+
+# parse-commit-description parses a commit description for any required sibling
+# to pass along to downstream job(s)...
+parse-commit-description() {
+  description="${1}"
+
+  # Looks specifically for matches of '[rR]equires <repo>#<sha>',
+  # e.g., "requires builder#abc1234, Requires router#def5678"
+  reqs=`echo "${description}" | grep -o "[Rr]equires [-a-z]*#[a-z0-9]*" | grep -o "[-a-z]*#[a-z0-9]*"` || true
+
+  # split on whitespace into array of '<repo>#<sha>' values
+  reqsArray=(${reqs// / })
+
+  # for each '<repo>#<sha>' value in array
+  for i in "${reqsArray[@]}"; do
+    # split on '#'
+    repoShaArray=(${i//#/ })
+    # echo '<uppercased repo>_SHA'=<sha> (with hyphens converted to underscores)
+    repoEnvVar=`echo "${repoShaArray[0]//-/_}" | awk '{print toupper($0)}'`_SHA
+    echo "${repoEnvVar}"="${repoShaArray[1]}"
+  done
+}
+
+main

--- a/bash/scripts/skip_e2e_check.sh
+++ b/bash/scripts/skip_e2e_check.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+main() {
+  check-skip-e2e "${ghprbPullLongDescription}"
+}
+
+# check-skip-e2e checks if 'skip e2e' is provided in commit body
+check-skip-e2e() {
+  description="${1}"
+
+  skipE2e=`echo "${description}" | grep -o "skip e2e"` || true
+
+  if [ -n "${skipE2e}" ]; then
+    echo "'skip e2e' found in commit body so skipping e2e test run"
+    exit 1
+  fi
+}
+
+main

--- a/bash/tests/commit_description_parser_test.bats
+++ b/bash/tests/commit_description_parser_test.bats
@@ -1,0 +1,68 @@
+#!/usr/bin/env bats
+
+setup() {
+  . "${BATS_TEST_DIRNAME}/../scripts/commit_description_parser.sh"
+}
+
+@test "parse-commit-description : no description given" {
+  description=""
+  run parse-commit-description "${description}"
+
+  [ "${status}" -eq 0 ]
+  [ "${output}" = "" ]
+}
+
+@test "parse-commit-description : description with no requirements" {
+  description="\
+    Just a regular PR here
+    No required commits...
+  "
+  run parse-commit-description "${description}"
+
+  [ "${status}" -eq 0 ]
+  [ "${output}" = "" ]
+}
+
+@test "parse-commit-description : description with requirements" {
+  description="\
+    A PR with required commits...
+    Requires repo-a#abc1234
+    requires repo-b#def5678
+  "
+  run parse-commit-description "${description}"
+
+  [ "${status}" -eq 0 ]
+  [ "${lines[0]}" = "REPO_A_SHA=abc1234" ]
+  [ "${lines[1]}" = "REPO_B_SHA=def5678" ]
+}
+
+@test "parse-commit-description : description with ill-formated requirements" {
+  description="\
+    A PR with required commits...
+    Requirez repo-a#abc1234
+    reqs repo-b#def5678
+  "
+  run parse-commit-description "${description}"
+
+  [ "${status}" -eq 0 ]
+  [ "${output}" = "" ]
+}
+
+@test "main : if on jenkins in jenkins-jobs workspace" {
+  export JENKINS_HOME="foo"
+  export JOB_BASE_NAME="jenkins-jobs"
+  run main
+
+  [ "${status}" -eq 0 ]
+  [ "${output}" = "" ]
+}
+
+@test "main : if on jenkins and not in jenkins-jobs workspace" {
+  export JENKINS_HOME="foo"
+  export JOB_BASE_NAME="bar"
+  run main
+
+  echo "${output}"
+  [ "${status}" -eq 1 ]
+  [[ "${output}" == *"Permission denied"* ]]
+}

--- a/bash/tests/skip_e2e_check_test.bats
+++ b/bash/tests/skip_e2e_check_test.bats
@@ -1,0 +1,35 @@
+#!/usr/bin/env bats
+
+setup() {
+  . "${BATS_TEST_DIRNAME}/../scripts/skip_e2e_check.sh"
+}
+
+@test "check-skip-e2e : no description given" {
+  description=""
+  run check-skip-e2e "${description}"
+
+  [ "${status}" -eq 0 ]
+  [ "${output}" = "" ]
+}
+
+@test "check-skip-e2e : description with no 'skip e2e'" {
+  description="\
+    Just a regular PR here
+    Want to run e2e for sure
+  "
+  run check-skip-e2e "${description}"
+
+  [ "${status}" -eq 0 ]
+  [ "${output}" = "" ]
+}
+
+@test "check-skip-e2e : description with 'skip e2e'" {
+  description="\
+    Just a regular PR here
+    [skip e2e]
+  "
+  run check-skip-e2e "${description}"
+
+  [ "${status}" -eq 1 ]
+  [ "${output}" = "'skip e2e' found in commit body so skipping e2e test run" ]
+}


### PR DESCRIPTION
This introduces an additional shell script into every Workflow component job to check if the `${ghprbPullLongDescription}` value (essentially, the commit message body, provided by the [GitHub Pull Request Builder Plug-in](https://wiki.jenkins-ci.org/display/JENKINS/GitHub+pull+request+builder+plugin)) contains any 'required' associated commits to include when running the downstream test job.

The format of said commit requiring proposed in this PR would be: `"[rR]equires repo#sha"`, e.g. 

```
requires builder#abc1234
Requires controller#ghi9123
```

TODO
- [x] PR related mention of functionality in https://github.com/deis/workflow/blob/master/src/contributing/submitting-a-pull-request.md
- [x] delete https://ci.deis.io/job/sibling-commit-tester-seed-job/

Ref https://github.com/deis/workflow/pull/321
Closes #54
