### PR TITLE
fix(jobs/workflow_test.groovy): check for UNSTABLE status

### DIFF
--- a/jobs/workflow_test.groovy
+++ b/jobs/workflow_test.groovy
@@ -53,7 +53,7 @@ import utilities.StatusUpdater
        }
 
        if (isPR) {
-         def statuses = [['SUCCESS', 'success'],['FAILURE', 'failure'],['ABORTED', 'error']]
+         def statuses = [['SUCCESS', 'success'],['FAILURE', 'failure'],['ABORTED', 'error'],['UNSTABLE', 'failure']]
          postBuildScripts {
            onlyIfBuildSucceeds(false)
            steps {


### PR DESCRIPTION
Currently, the test job can result in [UNSTABLE](https://ci.deis.io/job/workflow-test-pr/2380/console) after failures in the test
suite.  Therefore, we need to check for this result and report failure accordingly.

cc @arschles @jchauncey 
