### PR TITLE
fix(e2e_runner.groovy): always push both immutable and mutable e2e-runner images

### DIFF
--- a/jobs/e2e_runner.groovy
+++ b/jobs/e2e_runner.groovy
@@ -8,7 +8,7 @@ import utilities.StatusUpdater
   isMaster = config.type == 'master'
   isPR = config.type == 'pr'
   name = isMaster ? "e2e-runner" : "e2e-runner-${config.type}"
-  dockerPush = isPR ? 'docker-immutable-push' : 'docker-mutable-push'
+  dockerPush = 'docker-push'
   downstreamJobName = defaults.testJob[config.type]
 
   job(name) {

--- a/jobs/e2e_runner.groovy
+++ b/jobs/e2e_runner.groovy
@@ -8,7 +8,7 @@ import utilities.StatusUpdater
   isMaster = config.type == 'master'
   isPR = config.type == 'pr'
   name = isMaster ? "e2e-runner" : "e2e-runner-${config.type}"
-  dockerPush = 'docker-push'
+  dockerPush = isPR ? 'docker-immutable-push' : 'docker-push'
   downstreamJobName = defaults.testJob[config.type]
 
   job(name) {


### PR DESCRIPTION
On pushes to `master`.

Addresses test failures like https://ci.deis.io/job/workflow-test/624/testReport
