### PR TITLE
chore(jobs/workflow_test.groovy): explicitly define upstream params

### DIFF
--- a/jobs/workflow_test.groovy
+++ b/jobs/workflow_test.groovy
@@ -90,6 +90,8 @@ import utilities.StatusUpdater
         stringParam(repo.commitEnvVar, '', "${repo.name} commit SHA")
       }
       stringParam('WORKFLOW_CLI_SHA', '', "workflow-cli commit SHA")
+      stringParam('UPSTREAM_BUILD_URL', '', "Upstream build url")
+      stringParam('UPSTREAM_SLACK_CHANNEL', '', "Upstream Slack channel")
       stringParam('COMPONENT_REPO', '', "Component repo name")
       stringParam('ACTUAL_COMMIT', '', "Component commit SHA")
       stringParam('GINKGO_NODES', '30', "Number of parallel executors to use when running e2e tests")


### PR DESCRIPTION
Pre Jenkins 2.3, one could declare `predefinedProps` in an upstream job
and have those properties automatically be created in a downstream job.

Post-2.3, due to [security considerations](https://issues.jenkins-ci.org/browse/JENKINS-34871)
it appears any/all downstream jobs need to explicitly declare any properties/values
that it may be passed in a given pipeline.

This particular fix involves getting the correct values for `UPSTREAM_BUILD_URL` and `UPSTREAM_SLACK_CHANNEL`.  It also fixes incorrect indentation/spacing.

cc @mboersma 
