### PR TITLE
fix(jobs/<misc>): always use '${sha1}' for repo branch

### DIFF
--- a/jobs/component_jobs.groovy
+++ b/jobs/component_jobs.groovy
@@ -5,8 +5,8 @@ import utilities.StatusUpdater
 repos.each { Map repo ->
   [
     // for each repo, create a <repo.name>-master and <repo.name>-pr job
-    [type: 'master', branch: 'master'],
-    [type: 'pr', branch: '${sha1}'],
+    [type: 'master'],
+    [type: 'pr'],
   ].each { Map config ->
     isMaster = config.type == 'master'
     isPR = config.type == 'pr'
@@ -31,7 +31,7 @@ repos.each { Map repo ->
               refspec('+refs/pull/*:refs/remotes/origin/pr/*')
             }
           }
-          branch(config.branch)
+          branch('${sha1}')
         }
       }
 

--- a/jobs/e2e_runner.groovy
+++ b/jobs/e2e_runner.groovy
@@ -2,8 +2,8 @@ evaluate(new File("${WORKSPACE}/common.groovy"))
 
 import utilities.StatusUpdater
 
-[ [type: 'master', branch: 'master'],
-  [type: 'pr', branch: '${sha1}'],
+[ [type: 'master'],
+  [type: 'pr'],
 ].each { Map config ->
   isMaster = config.type == 'master'
   isPR = config.type == 'pr'
@@ -25,7 +25,7 @@ import utilities.StatusUpdater
             refspec('+refs/pull/*:refs/remotes/origin/pr/*')
           }
         }
-        branch(config.branch)
+        branch('${sha1}')
       }
     }
 

--- a/jobs/monitor_jobs.groovy
+++ b/jobs/monitor_jobs.groovy
@@ -15,8 +15,8 @@ dirs.each { Map dir ->
 dirs.each { Map dir ->
   [
     // for each repo, create a <dir.name>-master and <dir.name>-pr job
-    [type: 'master', branch: 'master'],
-    [type: 'pr', branch: '${sha1}'],
+    [type: 'master'],
+    [type: 'pr'],
   ].each { Map config ->
     isMaster = config.type == 'master'
     isPR = config.type == 'pr'
@@ -38,7 +38,7 @@ dirs.each { Map dir ->
             if (isPR) {
               refspec('+refs/pull/*:refs/remotes/origin/pr/*')
             }
-            branch(config.branch)
+            branch('${sha1}')
           }
         }
       }


### PR DESCRIPTION
Which [defaults](https://github.com/deis/jenkins-jobs/blob/master/jobs/component_jobs.groovy#L80) to `master` but can now properly be overridden.

cc @krancour 
