### PR TITLE
feat(component_release.groovy): add <component>-release job

### DIFF
--- a/bash/scripts/check_release_branch.sh
+++ b/bash/scripts/check_release_branch.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+main() {
+  check-release-branch
+}
+
+check-release-branch() {
+  if [ "${GIT_BRANCH}" != "origin/release-${RELEASE}" ]; then
+    echo "GIT_BRANCH (${GIT_BRANCH}) is not 'origin/release-${RELEASE}'; exiting build."
+    exit 0
+  fi
+  echo "Proceeding with build/deploy from 'origin/release-${RELEASE}'..."
+}

--- a/bash/tests/check_release_branch_test.bats
+++ b/bash/tests/check_release_branch_test.bats
@@ -1,0 +1,23 @@
+#!/usr/bin/env bats
+
+setup() {
+  . "${BATS_TEST_DIRNAME}/../scripts/check_release_branch.sh"
+}
+
+@test "check-release-branch : is non-release branch" {
+  export RELEASE='foo'
+  export GIT_BRANCH='origin/master'
+  run check-release-branch
+
+  [ "${status}" -eq 0 ]
+  [ "${output}" = "GIT_BRANCH (${GIT_BRANCH}) is not 'origin/release-${RELEASE}'; exiting build." ]
+}
+
+@test "check-release-branch : is release branch" {
+  export RELEASE='foo'
+  export GIT_BRANCH="origin/release-${RELEASE}"
+  run check-release-branch
+
+  [ "${status}" -eq 0 ]
+  [ "${output}" = "Proceeding with build/deploy from 'origin/release-${RELEASE}'..." ]
+}

--- a/common.groovy
+++ b/common.groovy
@@ -10,7 +10,6 @@ repos = [
   [name: 'router', slackChannel: 'router'],
   [name: 'slugbuilder', slackChannel: 'builder'],
   [name: 'slugrunner', slackChannel: 'builder'],
-  [name: 'stdout-metrics', slackChannel: 'metrics'],
   [name: 'controller', slackChannel: 'controller'],
   [name: 'workflow-e2e', slackChannel: 'testing'],
   [name: 'workflow-manager', slackChannel: 'wfm'],
@@ -42,6 +41,7 @@ defaults = [
   testJob: [
     master: "${TEST_JOB_ROOT_NAME}",
     pr: "${TEST_JOB_ROOT_NAME}-pr",
+    release: "${TEST_JOB_ROOT_NAME}-release",
     reportMsg: "Test Report: ${JENKINS_URL}job/\${JOB_NAME}/\${BUILD_NUMBER}/testReport",
     // Revisit when https://github.com/deis/jenkins-jobs/issues/51 complete
     // (timeout can/should be decreased)

--- a/jobs/component_release.groovy
+++ b/jobs/component_release.groovy
@@ -1,0 +1,87 @@
+evaluate(new File("${WORKSPACE}/common.groovy"))
+
+repos.each { Map repo ->
+
+  job("${repo.name}-release") {
+    description """
+      <li>Watches the ${repo.name} repo for commits on a given release-\${RELEASE} branch</li>
+      <li>to build and deploy images using said commits</li>
+    """.stripIndent().trim()
+
+    scm {
+      git {
+        remote {
+          github("deis/${repo.name}")
+          credentials('597819a0-b0b9-4974-a79b-3a5c2322606d')
+        }
+        branch('release-${RELEASE}')
+      }
+    }
+
+    concurrentBuild()
+
+    logRotator {
+      daysToKeep defaults.daysToKeep
+    }
+
+    parameters {
+      stringParam('DOCKER_USERNAME', 'deisbot', 'Docker Hub account name')
+      stringParam('DOCKER_EMAIL', 'dummy-address@deis.com', 'Docker Hub email address')
+      stringParam('QUAY_USERNAME', 'deisci+jenkins', 'Quay account name')
+      stringParam('QUAY_EMAIL', 'deisci+jenkins@deis.com', 'Quay email address')
+      stringParam('RELEASE', 'v2.2.0', 'Release to use for branch checkout')
+      booleanParam('RUN_E2E', false, 'check to run downstream release e2e job')
+    }
+
+    triggers {
+      githubPush()
+    }
+
+    wrappers {
+      timestamps()
+      colorizeOutput 'xterm'
+      credentialsBinding {
+        string("DOCKER_PASSWORD", "0d1f268f-407d-4cd9-a3c2-0f9671df0104")
+        string("QUAY_PASSWORD", "c67dc0a1-c8c4-4568-a73d-53ad8530ceeb")
+      }
+    }
+
+    steps {
+      shell new File("${WORKSPACE}/bash/scripts/check_release_branch.sh").text
+
+      shell '''
+        #!/usr/bin/env bash
+
+        set -eo pipefail
+
+        make bootstrap || true
+
+        export IMAGE_PREFIX=deisci
+        docker login -e="${DOCKER_EMAIL}" -u="${DOCKER_USERNAME}" -p="${DOCKER_PASSWORD}"
+        DEIS_REGISTRY='' make docker-build docker-immutable-push
+        docker login -e="${QUAY_EMAIL}" -u="${QUAY_USERNAME}" -p="${QUAY_PASSWORD}" quay.io
+        DEIS_REGISTRY=quay.io/ make docker-build docker-immutable-push
+      '''.stripIndent().trim()
+
+
+      conditionalSteps {
+        condition {
+          booleanCondition('RUN_E2E')
+        }
+        steps {
+          downstreamParameterized {
+            trigger(defaults.testJob['release']) {
+              parameters {
+                predefinedProps([
+                  "WORKFLOW_BRANCH": 'release-${RELEASE}',
+                  "WORKFLOW_E2E_BRANCH": 'release-${RELEASE}',
+                  "RELEASE": '${RELEASE}'
+                ])
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/jobs/workflow_test_release.groovy
+++ b/jobs/workflow_test_release.groovy
@@ -39,7 +39,7 @@ job(name) {
    }
 
   parameters {
-    stringParam('WORKFLOW_CLI_SHA', '', "workflow-cli commit SHA")
+    stringParam('WORKFLOW_CLI_SHA', '', "workflow-cli commit SHA (default: master HEAD commit if left blank)")
     stringParam('WORKFLOW_BRANCH', 'master', "The branch to use for installing the workflow chart.")
     stringParam('WORKFLOW_E2E_BRANCH', 'master', "The branch to use for installing the workflow-e2e chart.")
     stringParam('RELEASE', 'rc1', "Release string for resolving workflow-[release](-e2e) charts")


### PR DESCRIPTION
For all Workflow component repos, to watch for a commit on a given release branch,
specified via the RELEASE parameter.

Live example built from DSL on this branch: https://ci.deis.io/job/dockerbuilder-release/1/console

TODO
- [x] mark this as completed in https://github.com/deis/deisrel/issues/100 if/when merged
- [x] delete manually created `component-seed-job`

Closes #110 
Ref https://github.com/deis/workflow/pull/362
