### PR TITLE
fix(workflow_test.groovy): test job should default to 'dev' release

### DIFF
--- a/jobs/workflow_test.groovy
+++ b/jobs/workflow_test.groovy
@@ -95,7 +95,7 @@ import utilities.StatusUpdater
       stringParam('COMPONENT_REPO', '', "Component repo name")
       stringParam('ACTUAL_COMMIT', '', "Component commit SHA")
       stringParam('GINKGO_NODES', '30', "Number of parallel executors to use when running e2e tests")
-      stringParam('RELEASE', defaults.workflow.release, "Release string for resolving workflow-[release](-e2e) charts")
+      stringParam('RELEASE', 'dev', "Release string for resolving workflow-[release](-e2e) charts")
       stringParam('E2E_RUNNER_IMAGE', 'quay.io/deisci/e2e-runner:canary', "The e2e-runner image")
       stringParam('E2E_DIR', '/home/jenkins/workspace/$JOB_NAME/$BUILD_NUMBER', "Directory for storing workspace files")
       stringParam('E2E_DIR_LOGS', '${E2E_DIR}/logs', "Directory for storing logs. This directory is mounted into the e2e-runner container")


### PR DESCRIPTION
This value was erroneously updated in https://github.com/deis/jenkins-jobs/pull/130
