### PR TITLE
feat(component_jobs): use PR commit sha for docker tag

### DIFF
--- a/bash/scripts/get_actual_commit.sh
+++ b/bash/scripts/get_actual_commit.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+# Gets actual commit for reporting status and potentially tagging Docker image
+main() {
+  envPropsFilepath="/dev/null"
+  if [ -n "${JENKINS_HOME}" ]; then
+    envPropsFilepath="${WORKSPACE}/env.properties"
+  fi
+
+  export ACTUAL_COMMIT="${sha1}"
+  # if triggered by pull request plugin, use ghprbActualCommit
+  if [ "${ghprbActualCommit}" != "" ]; then
+    export ACTUAL_COMMIT="${ghprbActualCommit}"
+    export VERSION="git-${ACTUAL_COMMIT:0:7}"
+    echo "PR build, so using VERSION=${VERSION} for Docker image tag rather than the merge commit"
+  fi
+  echo ACTUAL_COMMIT="${ACTUAL_COMMIT}" > "${envPropsFilepath}"
+}
+
+main

--- a/bash/tests/get_actual_commit.bats
+++ b/bash/tests/get_actual_commit.bats
@@ -1,0 +1,21 @@
+#!/usr/bin/env bats
+
+setup() {
+  . "${BATS_TEST_DIRNAME}/../scripts/get_actual_commit.sh"
+}
+
+@test "get-actual-commit : is not PR" {
+  ghprbActualCommit=""
+  run main
+
+  [ "${status}" -eq 0 ]
+  [ "${output}" = "" ]
+}
+
+@test "get-actual-commit : is PR" {
+  ghprbActualCommit="abc1234def5678"
+  run main
+
+  [ "${status}" -eq 0 ]
+  [ "${output}" = "PR build, so using VERSION=git-abc1234 for Docker image tag rather than the merge commit" ]
+}

--- a/jobs/component_jobs.groovy
+++ b/jobs/component_jobs.groovy
@@ -96,6 +96,9 @@ repos.each { Map repo ->
 
       steps {
         dockerPush = isPR ? 'docker-immutable-push' : 'docker-push'
+
+        shell new File("${WORKSPACE}/bash/scripts/get_actual_commit.sh").text
+
         shell """
           #!/usr/bin/env bash
 
@@ -108,14 +111,6 @@ repos.each { Map repo ->
           DEIS_REGISTRY='' make docker-build ${dockerPush}
           docker login -e="\$QUAY_EMAIL" -u="\$QUAY_USERNAME" -p="\$QUAY_PASSWORD" quay.io
           DEIS_REGISTRY=quay.io/ make docker-build ${dockerPush}
-
-          # if triggered by pull request plugin, use ghprbActualCommit
-          export ACTUAL_COMMIT="\${ghprbActualCommit}"
-          # if manually triggered, use sha1
-          if [ -z "\${ghprbActualCommit}" ]; then
-            export ACTUAL_COMMIT="\${sha1}"
-          fi
-          echo ACTUAL_COMMIT="\${ACTUAL_COMMIT}" > \${WORKSPACE}/env.properties
         """.stripIndent().trim()
 
         shell new File("${WORKSPACE}/bash/scripts/commit_description_parser.sh").text


### PR DESCRIPTION
Rather than merge commit sha.  This enables e2e testing of
multiple 'sibling'/dependent PRs.

cc @helgi @sgoings
