### PR TITLE
fix(common.groovy): check if WORKFLOW_CLI_SHA empty

### DIFF
--- a/common.groovy
+++ b/common.groovy
@@ -28,7 +28,10 @@ set -eo pipefail
 
 export WORKFLOW_CHART="workflow-${RELEASE}"
 export WORKFLOW_E2E_CHART="workflow-${RELEASE}-e2e"
-export CLI_VERSION="${WORKFLOW_CLI_SHA:0:7}"
+
+if [ -n "${WORKFLOW_CLI_SHA}" ]; then
+  export CLI_VERSION="${WORKFLOW_CLI_SHA:0:7}"
+fi
 
 mkdir -p ${E2E_DIR_LOGS}
 env > ${E2E_DIR}/env.file


### PR DESCRIPTION
before overriding `CLI_VERSION`

Ref https://github.com/deis/workflow-e2e/pull/260
