### PR TITLE
fix(common.groovy): default CLI_VERSION to latest

### DIFF
--- a/common.groovy
+++ b/common.groovy
@@ -29,6 +29,7 @@ set -eo pipefail
 export WORKFLOW_CHART="workflow-${RELEASE}"
 export WORKFLOW_E2E_CHART="workflow-${RELEASE}-e2e"
 
+export CLI_VERSION="latest"
 if [ -n "${WORKFLOW_CLI_SHA}" ]; then
   export CLI_VERSION="${WORKFLOW_CLI_SHA:0:7}"
 fi


### PR DESCRIPTION
Since CLI_VERSION is checked before any workflow-e2e make target(s) are
invoked (said Makefile is where env var default is set currently)

Blocks https://github.com/deis/workflow-e2e/pull/260

cc @Joshua-Anderson @jchauncey 
