### PR TITLE
fix(workflow_cli_release.groovy): prepend branch name with 'refs/'

### DIFF
--- a/jobs/workflow_cli_release.groovy
+++ b/jobs/workflow_cli_release.groovy
@@ -15,7 +15,7 @@ job("${repoName}-tag-release") {
         credentials('597819a0-b0b9-4974-a79b-3a5c2322606d')
         refspec('+refs/tags/${RELEASE}:refs/remotes/origin/tags/${RELEASE}')
       }
-      branch('tags/${RELEASE}')
+      branch('refs/tags/${RELEASE}')
     }
   }
 


### PR DESCRIPTION
As this is the precise `ref` value used in the github webhook
on the tag push event.  Hoping this will be the key to trigger this
job (previously, just using `tags/${RELEASE}` didn't seem to catch the event)

Verified that this value picks up the correct ref in https://ci.deis.io/job/workflow-cli-tag-release/7/console
