### PR TITLE
feat(common): add registry-proxy as a component

### DIFF
--- a/common.groovy
+++ b/common.groovy
@@ -8,6 +8,7 @@ repos = [
   [name: 'postgres', slackChannel: 'postgres'],
   [name: 'redis', slackChannel: 'logger'],
   [name: 'registry', slackChannel: 'registry'],
+  [name: 'registry-proxy', slackChannel: 'registry'],
   [name: 'router', slackChannel: 'router'],
   [name: 'slugbuilder', slackChannel: 'builder'],
   [name: 'slugrunner', slackChannel: 'builder'],


### PR DESCRIPTION
registry-proxy is an nginx instance that proxies requests from local Docker daemons to the Deis
Workflow registry. See more at https://github.com/deis/registry-proxy
