### PR TITLE
fix(workflow_test.groovy): set allowEmptyResults to true for archiveJunit

### DIFF
--- a/jobs/workflow_test.groovy
+++ b/jobs/workflow_test.groovy
@@ -44,6 +44,7 @@ import utilities.StatusUpdater
 
        archiveJunit('${BUILD_NUMBER}/logs/junit*.xml') {
          retainLongStdout(false)
+         allowEmptyResults(true)
        }
 
        archiveArtifacts {


### PR DESCRIPTION
We now exit if we fail to retrieve artifacts (https://github.com/deis/e2e-runner/blob/master/scripts/run.sh#L65-L68) but we still see issues with the JUnit Plugin claiming falsely that test results cannot be found.  (See https://ci.deis.io/job/workflow-test-pr/4258/consoleFull wherein all specs passed _and_ the `junit*.xml` files were confirmed to be in the appropriate place of that job's workspace on the node it ran on.)

Therefore, I propose we add the `allowEmptyResults(true)` back in.  If logs can't be saved from the e2e pod, the job will fail as desired.  Otherwise, the logs will be saved to the workspace and can be retrieved easily even if the plugin thinks there are none.
