### PR TITLE
fix(workflow_test.groovy): allowEmpty patch for archiveArtifacts

### DIFF
--- a/jobs/workflow_test.groovy
+++ b/jobs/workflow_test.groovy
@@ -51,6 +51,7 @@ import utilities.StatusUpdater
          pattern('${BUILD_NUMBER}/logs/**')
          onlyIfSuccessful(false)
          fingerprint(false)
+         allowEmpty(true)
        }
 
        if (isPR) {


### PR DESCRIPTION
as done in https://github.com/deis/jenkins-jobs/pull/163

(note, for `archiveArtifacts`, `allowEmpty(..)` is used, whereas for `archiveJunit`, `allowEmptyResults(..)` is used, per [here](https://jenkinsci.github.io/job-dsl-plugin/#method/javaposse.jobdsl.dsl.helpers.publisher.PublisherContext.archiveJunit) and [here](https://jenkinsci.github.io/job-dsl-plugin/#method/javaposse.jobdsl.dsl.helpers.publisher.PublisherContext.archiveArtifacts).)
