### PR TITLE
ref(component_tag_release.groovy): revisit release pipeline

### DIFF
--- a/bash/scripts/locate_release_candidate.sh
+++ b/bash/scripts/locate_release_candidate.sh
@@ -12,18 +12,8 @@ main() {
   if [ -n "${TAG}" ]; then
     echo "TAG set to '${TAG}', attempting release of this tag..."
     tag="${TAG}"
-  elif [ -n "${GIT_BRANCH}" ]; then
-    echo "GIT_BRANCH set to '${GIT_BRANCH}', attempting release of this tag..."
-    tag="${GIT_BRANCH#origin/tags/}"
-
-    # make sure tag matches latest; else, exit
-    latest_tag="${LATEST_COMPONENT_TAG:-$(git tag -l | tail -n1)}"
-    if [ "${latest_tag}" != "${tag}" ]; then
-      echo "Latest tag of '${latest_tag}' does not match '${tag}'; not proceeding with release."
-      exit 0
-    fi
   else
-    echo "GIT_BRANCH or TAG not set, cannot determine tag to release; exiting."
+    echo "TAG not set, cannot determine tag to release; exiting."
     exit 1
   fi
 

--- a/bash/tests/locate_release_candidate_test.bats
+++ b/bash/tests/locate_release_candidate_test.bats
@@ -10,44 +10,11 @@ teardown() {
   rm_stubs
 }
 
-@test "main : TAG and GIT_BRANCH not set" {
+@test "main : TAG not set" {
   run main
 
   [ "${status}" -eq 1 ]
-  [ "${output}" = "GIT_BRANCH or TAG not set, cannot determine tag to release; exiting." ]
-}
-
-@test "main : TAG not set - GIT_BRANCH set - does not match latest" {
-  export GIT_BRANCH="origin/tags/foo-tag"
-  export LATEST_COMPONENT_TAG="bar-tag"
-  export COMPONENT_NAME="my-component"
-  export COMPONENT_SHA="abc1234def5678"
-
-  run main
-
-  [ "${status}" -eq 0 ]
-  [ "${lines[0]}" = "GIT_BRANCH set to 'origin/tags/foo-tag', attempting release of this tag..." ]
-  [ "${lines[1]}" = "Latest tag of 'bar-tag' does not match 'foo-tag'; not proceeding with release." ]
-}
-
-@test "main : TAG not set - GIT_BRANCH set - matches latest" {
-  export GIT_BRANCH="origin/tags/foo-tag"
-  export LATEST_COMPONENT_TAG="foo-tag"
-  export COMPONENT_NAME="my-component"
-  export COMPONENT_SHA="abc1234def5678"
-
-  # expected env.properties output
-  { echo COMPONENT_NAME=my-component; \
-    echo COMPONENT_SHA=abc1234def5678; \
-    echo RELEASE_TAG=foo-tag; \
-    echo MY_COMPONENT_SHA=abc1234def5678; } > ${BATS_TEST_DIRNAME}/tmp/expected.env.properties
-
-  run main
-
-  [ "${status}" -eq 0 ]
-  [ "${lines[0]}" = "GIT_BRANCH set to 'origin/tags/foo-tag', attempting release of this tag..." ]
-  [ "${lines[1]}" = "Locating candidate release image quay.io/deis/my-component:git-abc1234..." ]
-  [ "$(cmp ${BATS_TEST_DIRNAME}/tmp/env.properties ${BATS_TEST_DIRNAME}/tmp/expected.env.properties)" = "" ]
+  [ "${output}" = "TAG not set, cannot determine tag to release; exiting." ]
 }
 
 @test "main : TAG set" {


### PR DESCRIPTION
Instead of hingeing on a git webhook trigger (which has proven faulty/overzealous
in running on webhooks other than the latest tag push event), refactor
pipeline to kick off manually with provided TAG value.  The new pipeline will then:
1. locate release candidate off of latest commit in master
2. if successful (meaning that commit has been vetted by e2e), run 'git tag TAG' commands
3. kick off e2e against release candidate
4. if successful, retag release candidate with TAG in docker registries
