### PR TITLE
feat(workflow_test.groovy): skip component promote if workflow-cli

### DIFF
--- a/bash/scripts/get_component_and_sha.sh
+++ b/bash/scripts/get_component_and_sha.sh
@@ -4,10 +4,7 @@ set -eo pipefail
 
 # Breaks up a <COMPONENT>_SHA env var into component name and sha
 main() {
-  envPropsFilepath="/dev/null"
-  if [ -n "${JENKINS_HOME}" ]; then
-    envPropsFilepath="${WORKSPACE}/${BUILD_NUMBER}/env.properties"
-  fi
+  envPropsFilepath="${ENV_PROPS_FILEPATH:-${WORKSPACE}/${BUILD_NUMBER}/env.properties}"
 
   # populate env_var_array with all <COMPONENT>_SHA env vars
   IFS=' ' read -r -a env_var_array <<< "$(compgen -A variable | grep _SHA)"
@@ -18,9 +15,13 @@ main() {
       component_name="$(echo "${env_var%_SHA}" | perl -ne 'print lc' | sed 's/_/-/g')"
       component_sha="${!env_var}"
 
+      if [ "${component_name}" == 'workflow-cli' ]; then
+        echo SKIP_COMPONENT_PROMOTE=true >> "${envPropsFilepath}"
+      fi
+
       echo "Found component '${component_name}' with commit sha '${component_sha}'"
-      echo COMPONENT_NAME="${component_name}" >> "${envPropsFilepath}"
-      echo COMPONENT_SHA="${component_sha}"  >> "${envPropsFilepath}"
+      { echo COMPONENT_NAME="${component_name}"; \
+        echo COMPONENT_SHA="${component_sha}"; } >> "${envPropsFilepath}"
     fi
   done
 }

--- a/bash/tests/get_component_and_sha.bats
+++ b/bash/tests/get_component_and_sha.bats
@@ -2,12 +2,37 @@
 
 setup() {
   . "${BATS_TEST_DIRNAME}/../scripts/get_component_and_sha.sh"
+  load stub
+  ENV_PROPS_FILEPATH="${BATS_TEST_DIRNAME}/tmp/env.properties"
+}
+
+teardown() {
+  rm_stubs
 }
 
 @test "main : gets component and sha" {
   export MY_COMPONENT_SHA="abc1234def5678"
   run main
-  echo "${output}"
+
+  # expected env.properties
+  { echo COMPONENT_NAME="my-component"; \
+    echo COMPONENT_SHA="abc1234def5678"; } >> "${BATS_TEST_DIRNAME}/tmp/expected.env.properties"
+
   [ "${status}" -eq 0 ]
   [ "${output}" = "Found component 'my-component' with commit sha 'abc1234def5678'" ]
+  [ "$(cmp ${BATS_TEST_DIRNAME}/tmp/env.properties ${BATS_TEST_DIRNAME}/tmp/expected.env.properties)" = "" ]
+}
+
+@test "main : skip promotion if workflow-cli" {
+  export WORKFLOW_CLI_SHA="abc1234def5678"
+  run main
+
+  # expected env.properties
+  { echo SKIP_COMPONENT_PROMOTE=true; \
+    echo COMPONENT_NAME="workflow-cli"; \
+    echo COMPONENT_SHA="abc1234def5678"; } >> "${BATS_TEST_DIRNAME}/tmp/expected.env.properties"
+
+  [ "${status}" -eq 0 ]
+  [ "${output}" = "Found component 'workflow-cli' with commit sha 'abc1234def5678'" ]
+  [ "$(cmp ${BATS_TEST_DIRNAME}/tmp/env.properties ${BATS_TEST_DIRNAME}/tmp/expected.env.properties)" = "" ]
 }

--- a/bash/tests/stub.bash
+++ b/bash/tests/stub.bash
@@ -1,11 +1,11 @@
 export TMP_STUB_PATH=tmp
 export PATH="${BATS_TEST_DIRNAME}/${TMP_STUB_PATH}:${PATH}"
 
-stub() {
-  if [ ! -d ${BATS_TEST_DIRNAME}/${TMP_STUB_PATH} ]; then
-    mkdir -p ${BATS_TEST_DIRNAME}/${TMP_STUB_PATH}
-  fi
+if [ ! -d ${BATS_TEST_DIRNAME}/${TMP_STUB_PATH} ]; then
+  mkdir -p ${BATS_TEST_DIRNAME}/${TMP_STUB_PATH}
+fi
 
+stub() {
   echo "${2}" > ${BATS_TEST_DIRNAME}/${TMP_STUB_PATH}/${1}
   chmod +x ${BATS_TEST_DIRNAME}/${TMP_STUB_PATH}/${1}
 }

--- a/jobs/component_promote.groovy
+++ b/jobs/component_promote.groovy
@@ -48,8 +48,8 @@ job('component-promote') {
 
       set -eo pipefail
 
-      if [ "${COMPONENT_NAME}" == "workflow-cli" ]; then
-        echo "Component to promote is 'workflow-cli' which has no Docker image form; exiting..."
+      if [ -z "${COMPONENT_NAME}" ]; then
+        echo "COMPONENT_NAME is empty; no component to promote; exiting..."
         exit 0
       fi
 

--- a/jobs/workflow_test.groovy
+++ b/jobs/workflow_test.groovy
@@ -134,10 +134,19 @@ import utilities.StatusUpdater
       if (isMaster) {
         shell new File("${WORKSPACE}/bash/scripts/get_component_and_sha.sh").text
 
-        downstreamParameterized {
-          trigger('component-promote') {
-            parameters {
-              propertiesFile('${WORKSPACE}/${BUILD_NUMBER}/env.properties')
+        conditionalSteps {
+          condition {
+            not {
+              shell 'cat "${WORKSPACE}/${BUILD_NUMBER}/env.properties" | grep -q SKIP_COMPONENT_PROMOTE'
+            }
+          }
+          steps {
+            downstreamParameterized {
+              trigger('component-promote') {
+                parameters {
+                  propertiesFile('${WORKSPACE}/${BUILD_NUMBER}/env.properties')
+                }
+              }
             }
           }
         }


### PR DESCRIPTION
Although the downstream `component-promote` job doesn't do anything (just exists 0) if component is workflow-cli (this PR changes that to just check if empty), we might as well just not trigger it, to cut down on the noise.

cc @Joshua-Anderson 
