### PR TITLE
fix(workflow_cli_release): remove GIT_TAG override

### DIFF
--- a/jobs/workflow_cli_release.groovy
+++ b/jobs/workflow_cli_release.groovy
@@ -59,7 +59,7 @@ job("${repoName}-tag-release") {
 
       cat "\${GCSKEY}" > /tmp/workflow-cli-release/key.json
 
-      GIT_TAG="\${RELEASE}" make bootstrap build-revision fileperms
+      make bootstrap build-revision fileperms
 
       ${gcloud} gcloud auth activate-service-account -q --key-file /.config/key.json
       ${gcloud} gsutil -mq cp -a public-read -r /upload/* ${gcs_bucket}


### PR DESCRIPTION
It shouldn't be necessary. Now the CLI uses git to figure out how to version itself.
