### PR TITLE
chore(clusterator_jobs.groovy): knock GKE cluster version back to 1.2.6

### DIFF
--- a/jobs/clusterator_jobs.groovy
+++ b/jobs/clusterator_jobs.groovy
@@ -15,7 +15,7 @@ job("clusterator-create") {
     stringParam('NUMBER_OF_CLUSTERS', '10', 'Number of clusters to create at 1 time')
     stringParam('NUM_NODES', '5', 'Number of nodes in each cluster')
     stringParam('MACHINE_TYPE', 'n1-standard-4', 'Node type')
-    stringParam('VERSION', '1.3.4', 'The version of kubernetes to use.')
+    stringParam('VERSION', '1.2.6', 'The version of kubernetes to use.')
   }
 
   wrappers {


### PR DESCRIPTION
Until we figure out why ci clusters brought up w/ version 1.3.4 are unhealthy.  

Example: https://ci.deis.io/job/workflow-test/1792/console
