### PR TITLE
ref(*): stop reporting success or aborted

### DIFF
--- a/jobs/component_jobs.groovy
+++ b/jobs/component_jobs.groovy
@@ -35,6 +35,13 @@ repos.each { Map repo ->
         }
       }
 
+      publishers {
+        slackNotifications {
+          notifyFailure()
+          notifyRepeatedFailure()
+         }
+       }
+
       if (isPR) {
         concurrentBuild()
         throttleConcurrentBuilds {

--- a/jobs/component_promote.groovy
+++ b/jobs/component_promote.groovy
@@ -19,7 +19,7 @@ job('component-promote') {
   publishers {
     slackNotifications {
       notifyFailure()
-      notifySuccess()
+      notifyRepeatedFailure()
     }
   }
 

--- a/jobs/component_release.groovy
+++ b/jobs/component_release.groovy
@@ -31,9 +31,7 @@ repos.each { Map repo ->
 
     publishers {
       slackNotifications {
-        notifyAborted()
         notifyFailure()
-        notifySuccess()
         notifyRepeatedFailure()
        }
      }

--- a/jobs/release_candidate_e2e.groovy
+++ b/jobs/release_candidate_e2e.groovy
@@ -14,9 +14,8 @@ job(name) {
   publishers {
     slackNotifications {
       customMessage(defaults.testJob["reportMsg"])
-      notifyAborted()
       notifyFailure()
-      notifySuccess()
+      notifyRepeatedFailure()
       includeTestSummary()
      }
 

--- a/jobs/release_candidate_promote.groovy
+++ b/jobs/release_candidate_promote.groovy
@@ -15,7 +15,7 @@ job('release-candidate-promote') {
   publishers {
     slackNotifications {
       notifyFailure()
-      notifySuccess()
+      notifyRepeatedFailure()
     }
   }
 

--- a/jobs/storage_test.groovy
+++ b/jobs/storage_test.groovy
@@ -40,7 +40,6 @@ name = "storagetype_e2e"
     slackNotifications {
       customMessage(defaults.testJob["reportMsg"])
       notifyFailure()
-      notifySuccess()
       includeTestSummary()
     }
 

--- a/jobs/workflow_cli_release.groovy
+++ b/jobs/workflow_cli_release.groovy
@@ -22,7 +22,7 @@ job("${repoName}-tag-release") {
   publishers {
     slackNotifications {
       notifyFailure()
-      notifySuccess()
+      notifyRepeatedFailure()
     }
   }
 

--- a/jobs/workflow_test.groovy
+++ b/jobs/workflow_test.groovy
@@ -36,10 +36,8 @@ import utilities.StatusUpdater
         // integrationToken('${SLACK_INTEGRATION_TOKEN}')
         // projectChannel('#${UPSTREAM_SLACK_CHANNEL}')
         customMessage([commitAuthorMsg, testReportMsg, upstreamJobMsg].join('\n'))
-        notifyAborted()
         notifyFailure()
         notifyRepeatedFailure()
-        notifySuccess()
         showCommitList()
         includeTestSummary()
        }

--- a/jobs/workflow_test_release.groovy
+++ b/jobs/workflow_test_release.groovy
@@ -26,9 +26,7 @@ job(name) {
   publishers {
     slackNotifications {
       customMessage(defaults.testJob["reportMsg"])
-      notifyAborted()
       notifyFailure()
-      notifySuccess()
       includeTestSummary()
      }
 


### PR DESCRIPTION
just report failure/repeated failure.

As nice as it is to see the successes, the thinking was we'd reduce the noise (currently it all routes to the #testing channel) and emphasize that a slack notification from Jenkins means there is an issue to be investigated...
