### PR TITLE
feat(*): enable requiring a deis/charts commit

### DIFF
--- a/bash/scripts/find_required_commits.sh
+++ b/bash/scripts/find_required_commits.sh
@@ -4,8 +4,8 @@ set -eo pipefail
 # find-required-commits parses a commit description for any required sibling
 # commits to pass along to downstream job(s)...
 find-required-commits() {
-  local git_commit="${1}"
-  local commit_description="${COMMIT_DESCRIPTION:-$(git log --format=%B -n 1 "${git_commit}")}"
+  git_commit="${1}"
+  commit_description="${COMMIT_DESCRIPTION:-$(git log --format=%B -n 1 "${git_commit}")}"
 
   # Looks specifically for matches of '[rR]equires <repo>#<pr_number>',
   # e.g., "requires builder#123, Requires router#567"

--- a/bash/scripts/get_component_and_sha.sh
+++ b/bash/scripts/get_component_and_sha.sh
@@ -13,7 +13,7 @@ get-component-and-sha() {
       component_name="$(echo "${env_var%_SHA}" | perl -ne 'print lc' | sed 's/_/-/g')"
       component_sha="${!env_var}"
 
-      if [ "${component_name}" == 'workflow-cli' ]; then
+      if [ "${component_name}" == 'workflow-cli' ] || [ "${component_name}" == 'charts' ]; then
         echo SKIP_COMPONENT_PROMOTE=true
       fi
 

--- a/bash/scripts/run_e2e.sh
+++ b/bash/scripts/run_e2e.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+run-e2e() {
+  local default_env_file="${1}"
+
+  export WORKFLOW_CHART="workflow-${RELEASE}"
+  export WORKFLOW_E2E_CHART="workflow-${RELEASE}-e2e"
+
+  export CLI_VERSION="${CLI_VERSION:-latest}"
+  if [ -n "${WORKFLOW_CLI_SHA}" ]; then
+    export CLI_VERSION="${WORKFLOW_CLI_SHA:0:7}"
+  fi
+
+  mkdir -p "${E2E_DIR_LOGS}"
+  env > "${E2E_DIR}"/env.file
+  if [ -e "${default_env_file}" ]; then
+    cat "${default_env_file}" >> "${E2E_DIR}"/env.file
+  fi
+
+  docker pull "${E2E_RUNNER_IMAGE}" # bust the cache as tag may be canary
+  docker run \
+    -u jenkins:jenkins \
+    --env-file="${E2E_DIR}"/env.file \
+    -v "${E2E_DIR_LOGS}":/home/jenkins/logs:rw "${E2E_RUNNER_IMAGE}"
+}

--- a/bash/scripts/setup_helmc_environment.sh
+++ b/bash/scripts/setup_helmc_environment.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+setup-helmc-env() {
+  if [ -n "${CHARTS_SHA}" ]; then
+    helmc_remote_repo="$(get-remote-repo-url charts "${CHARTS_SHA}")"
+    info="\
+      Found CHARTS_SHA='${CHARTS_SHA}'
+      Exporting the following env vars for setting up the local helmc environment:
+        HELM_REMOTE_REPO=${helmc_remote_repo}
+        WORKFLOW_BRANCH=${CHARTS_SHA}
+        WORKFLOW_E2E_BRANCH=${CHARTS_SHA}
+      "
+    log-info "${info}"
+
+    { echo HELM_REMOTE_REPO="${helmc_remote_repo}"; \
+      echo WORKFLOW_BRANCH="${CHARTS_SHA}"; \
+      echo WORKFLOW_E2E_BRANCH="${CHARTS_SHA}"; }
+  fi
+}
+
+get-remote-repo-url() {
+  repo_name="${1}"
+  git_commit="${2}"
+
+  # retrieve git commit info
+  commit_info=$(curl \
+  -fsSL \
+  --user deis-admin:"${GITHUB_ACCESS_TOKEN}" \
+  "https://api.github.com/repos/deis/${repo_name}/commits/${git_commit}")
+
+  committer_name="$(echo "${commit_info}" | docker run -i --rm kamermans/jq '.commit.committer.name')"
+
+  if [ "${committer_name//\"}" == "GitHub" ]; then
+    # commit has presumably been merged
+    echo "https://github.com/deis/${repo_name}.git"
+  else
+    # determine url to retrieve list of committer repos from commit info
+    committer_repos_url="$(echo "${commit_info}" | docker run -i --rm kamermans/jq '.committer.repos_url')"
+
+    # retrieve list of committer repos
+    committer_all_repos=$(curl \
+    -fsSL \
+    --user deis-admin:"${GITHUB_ACCESS_TOKEN}" \
+    "${committer_repos_url//\"}")
+
+    # determine ${repo_name} clone url from list of committer repos
+    clone_url="$(echo "${committer_all_repos}" | docker run -i --rm kamermans/jq '.[].clone_url' | grep "${repo_name}")"
+
+    # return clone url with double-quotes stripped
+    echo "${clone_url//\"}"
+  fi
+}
+
+log-info() {
+  local info="${1}"
+
+  if [ -n "${JENKINS_HOME}" ]; then
+    echo "${info}" >&2
+  fi
+}

--- a/bash/scripts/skip_e2e_check.sh
+++ b/bash/scripts/skip_e2e_check.sh
@@ -3,8 +3,8 @@ set -eo pipefail
 
 # check-skip-e2e checks if 'skip e2e' is provided in commit body
 check-skip-e2e() {
-  local git_commit="${1}"
-  local commit_description="${COMMIT_DESCRIPTION:-$(git log --format=%B -n 1 "${git_commit}")}"
+  git_commit="${1}"
+  commit_description="${COMMIT_DESCRIPTION:-$(git log --format=%B -n 1 "${git_commit}")}"
 
   skipE2e=$(echo "${commit_description}" | grep -o "skip e2e") || true
 

--- a/bash/tests/run_e2e_test.bats
+++ b/bash/tests/run_e2e_test.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+
+setup() {
+  . "${BATS_TEST_DIRNAME}/../scripts/run_e2e.sh"
+  load stub
+  stub docker
+  stub mkdir
+
+  E2E_DIR="${BATS_TEST_DIRNAME}/tmp"
+  E2E_DIR_LOGS="${E2E_DIR}/logs"
+  RELEASE="dev"
+}
+
+teardown() {
+  rm_stubs
+}
+
+@test "run-e2e : bogus default env file" {
+
+  run run-e2e "bogus/default/env/file"
+
+  [ "${status}" -eq 0 ]
+  [ "${output}" == "" ]
+  [[ -e "${E2E_DIR_LOGS}" ]]
+  [[ "$(cat "${E2E_DIR}/env.file")" == *"CLI_VERSION=latest"* ]]
+}
+
+@test "run-e2e : real default env file" {
+  default_env_file="${BATS_TEST_DIRNAME}/tmp/default_env.file"
+
+  echo "FOO=bar" > "${default_env_file}"
+
+  run run-e2e "${default_env_file}"
+
+  [ "${status}" -eq 0 ]
+  [ "${output}" == "" ]
+  [ -e "${E2E_DIR_LOGS}" ]
+  [[ "$(cat "${E2E_DIR}/env.file")" == *"CLI_VERSION=latest"*"FOO=bar"* ]]
+}
+
+@test "run-e2e : WORKFLOW_CLI_SHA set" {
+  WORKFLOW_CLI_SHA="abc1234def5678"
+
+  run run-e2e "bogus/default/env/file"
+
+  [ "${status}" -eq 0 ]
+  [ "${output}" == "" ]
+  [ -e "${E2E_DIR_LOGS}" ]
+  [[ "$(cat "${E2E_DIR}/env.file")" == *"CLI_VERSION=abc1234"* ]]
+}

--- a/bash/tests/setup_helmc_environment_test.bats
+++ b/bash/tests/setup_helmc_environment_test.bats
@@ -1,0 +1,79 @@
+#!/usr/bin/env bats
+
+setup() {
+  . "${BATS_TEST_DIRNAME}/../scripts/setup_helmc_environment.sh"
+  load stub
+  stub docker
+  stub curl
+}
+
+teardown() {
+  rm_stubs
+}
+
+# setup-helmc-env tests
+
+@test "setup-helmc-env: CHARTS_SHA empty" {
+  CHARTS_SHA=""
+
+  run setup-helmc-env "${TEST_ENV_FILE}"
+
+  [ "${status}" -eq 0 ]
+  [ "${output}" == "" ]
+}
+
+@test "setup-helmc-env: CHARTS_SHA populated" {
+  CHARTS_SHA="abc1234def5678"
+  repo_name="repo"
+  helmc_remote_repo="https://some/remote/charts/${repo_name}.git"
+
+  load stubs/tpl/default
+  # stub so that get-remote-repo-url returns ${helmc_remote_repo}
+  stub grep "$(generate-stub "charts" ${helmc_remote_repo})" 0
+
+  run setup-helmc-env
+
+  [ "${status}" -eq 0 ]
+  [ "${lines[0]}" == "HELM_REMOTE_REPO=${helmc_remote_repo}" ]
+  [ "${lines[1]}" == "WORKFLOW_BRANCH=${CHARTS_SHA}" ]
+  [ "${lines[2]}" == "WORKFLOW_E2E_BRANCH=${CHARTS_SHA}" ]
+}
+
+# get-remote-repo-url tests
+
+@test "get-remote-repo-url: commit info not found" {
+  repo_name="repo-a"
+  git_commit="abc1234def5678"
+
+  run get-remote-repo-url "${repo_name}" "${git_commit}"
+
+  [ "${status}" -eq 0 ]
+  [ "${output}" == "" ]
+}
+
+@test "get-remote-repo-url: correct repo found, still pr" {
+  repo_name="repo-a"
+  git_commit="abc1234def5678"
+
+  urls="\
+\"https://github.com/user/foo.git\"
+\"https://github.com/user/${repo_name}.git\"
+"
+  stub docker "echo '${urls}'"
+
+  run get-remote-repo-url "${repo_name}" "${git_commit}"
+
+  [ "${output}" == "https://github.com/user/${repo_name}.git" ]
+}
+
+@test "get-remote-repo-url: correct repo found, merged" {
+  repo_name="repo-a"
+  git_commit="abc1234def5678"
+
+  # We check committer name; if GitHub, assume it had been merged
+  stub docker "echo 'GitHub'"
+
+  run get-remote-repo-url "${repo_name}" "${git_commit}"
+
+  [ "${output}" == "https://github.com/deis/${repo_name}.git" ]
+}

--- a/bash/tests/stubs/tpl/default.bash
+++ b/bash/tests/stubs/tpl/default.bash
@@ -1,0 +1,10 @@
+generate-stub() {
+  stub_arg="${1}"
+  return_value="${2}"
+
+  cat <<EOF
+    case "\${1}" in
+      ("${stub_arg}") echo '"${return_value}"' ;;
+    esac
+EOF
+}

--- a/common.groovy
+++ b/common.groovy
@@ -3,26 +3,6 @@ evaluate(new File("${WORKSPACE}/repo.groovy"))
 WORKFLOW_RELEASE = 'v2.4.2'
 TEST_JOB_ROOT_NAME = 'workflow-test'
 
-E2E_RUNNER_JOB = '''#!/usr/bin/env bash
-set -eo pipefail
-
-export WORKFLOW_CHART="workflow-${RELEASE}"
-export WORKFLOW_E2E_CHART="workflow-${RELEASE}-e2e"
-
-export CLI_VERSION="${CLI_VERSION:-latest}"
-if [ -n "${WORKFLOW_CLI_SHA}" ]; then
-  export CLI_VERSION="${WORKFLOW_CLI_SHA:0:7}"
-fi
-
-mkdir -p ${E2E_DIR_LOGS}
-env > ${E2E_DIR}/env.file
-if [ -e "/tmp/${JOB_NAME}/${BUILD_NUMBER}/env.properties" ]; then
-  cat /tmp/${JOB_NAME}/${BUILD_NUMBER}/env.properties >> ${E2E_DIR}/env.file
-fi
-docker pull ${E2E_RUNNER_IMAGE} # bust the cache as tag may be canary
-docker run -u jenkins:jenkins --env-file=${E2E_DIR}/env.file -v ${E2E_DIR_LOGS}:/home/jenkins/logs:rw $E2E_RUNNER_IMAGE
-'''.stripIndent()
-
 defaults = [
   tmpPath: '/tmp/${JOB_NAME}/${BUILD_NUMBER}',
   envFile: '/tmp/${JOB_NAME}/${BUILD_NUMBER}/env.properties',
@@ -57,3 +37,6 @@ defaults = [
     credentialsID: '8e11254f-44f3-4ddd-bf98-2cabcb7434cd',
   ],
 ]
+
+e2eRunnerJob = new File("${WORKSPACE}/bash/scripts/run_e2e.sh").text +
+  "run-e2e ${defaults.envFile}"

--- a/jobs/apptypes_test.groovy
+++ b/jobs/apptypes_test.groovy
@@ -54,7 +54,6 @@ job(name) {
         echo UPSTREAM_SLACK_CHANNEL="testing"; } >> ${defaults.envFile}
     """.stripIndent().trim()
 
-    shell E2E_RUNNER_JOB
-
+    shell e2eRunnerJob
   }
 }

--- a/jobs/release_candidate_e2e.groovy
+++ b/jobs/release_candidate_e2e.groovy
@@ -66,6 +66,6 @@ job(name) {
   }
 
   steps {
-    shell E2E_RUNNER_JOB
+    shell e2eRunnerJob
   }
 }

--- a/jobs/storage_test.groovy
+++ b/jobs/storage_test.groovy
@@ -86,6 +86,6 @@ job(name) {
       echo \${TYPE}_DATABASE_BUCKET="store-database-\${BUILD_NUMBER}" >> ${defaults.envFile}
     """.stripIndent().trim()
 
-    shell E2E_RUNNER_JOB
+    shell e2eRunnerJob
   }
 }

--- a/jobs/workflow_test_release.groovy
+++ b/jobs/workflow_test_release.groovy
@@ -77,6 +77,6 @@ job(name) {
   }
 
   steps {
-    shell E2E_RUNNER_JOB
+    shell e2eRunnerJob
   }
 }


### PR DESCRIPTION
We already are set up to parse a required PR in any deis repo
provided it is mentioned in the git commit body, e.g. `Requires deis/<repo>#<pr_number>`

(Previously, we only actually performed subsequent logic if it was a Workflow component repo.)

This sets us up so that we can perform logic if the required PR is in the (presumably forked) deis/charts repo.  

This logic consists of determining the appropriate repo clone url alongside the charts commit sha and passing this info down do the downstream e2e job so that it can set up its local helmc instance appropriately, before fetching charts.

Closes https://github.com/deis/jenkins-jobs/issues/151

TODO: manually test the added logic in this PR by:
- [x] running the branch through Jenkins to be sure it parses correctly
- [x] create a `workflow-test`-clone with logic hingeing off `CHARTS_SHA`
- [x] issuing a test pr in a Workflow component repo requiring a PR in charts, with this logic running on Jenkins
- [ ] delete https://ci.deis.io/job/require-charts-pr-seed-job/ once this is merged
