### PR TITLE
fix(workflow_cli_release.groovy): file param should be a string param

### DIFF
--- a/jobs/workflow_cli_release.groovy
+++ b/jobs/workflow_cli_release.groovy
@@ -43,7 +43,7 @@ job("${repoName}-release") {
     timestamps()
     colorizeOutput 'xterm'
     credentialsBinding {
-      file("GCSKEY", "6561701c-b7b4-4796-83c4-9d87946799e4")
+      stringParam("GCSKEY", "6561701c-b7b4-4796-83c4-9d87946799e4")
     }
   }
 


### PR DESCRIPTION
That credentials id maps to a (base64 encoded) string, not a file.
