### PR TITLE
fix(jobs/workflow_cli_release.groovy): s/stringParam/string

### DIFF
--- a/jobs/workflow_cli_release.groovy
+++ b/jobs/workflow_cli_release.groovy
@@ -43,7 +43,7 @@ job("${repoName}-release") {
     timestamps()
     colorizeOutput 'xterm'
     credentialsBinding {
-      stringParam("GCSKEY", "6561701c-b7b4-4796-83c4-9d87946799e4")
+      string("GCSKEY", "6561701c-b7b4-4796-83c4-9d87946799e4")
     }
   }
 


### PR DESCRIPTION
Per https://jenkinsci.github.io/job-dsl-plugin/#path/javaposse.jobdsl.dsl.helpers.wrapper.WrapperContext.credentialsBinding-string (and examples in other jobs here that I neglected to double-check 😬 )
