### PR TITLE
fix(get_actual_commit.sh): curl GH API for actual pr commit, if pr

### DIFF
--- a/bash/scripts/get_actual_commit.sh
+++ b/bash/scripts/get_actual_commit.sh
@@ -3,18 +3,32 @@
 set -eo pipefail
 
 get-actual-commit() {
+  repo_name="${1}"
   git_branch="${GIT_BRANCH:-$(git describe --all)}"
   git_commit="${GIT_COMMIT:-$(git rev-parse HEAD)}"
 
   if [[ "${git_branch}" != *"master"* ]]; then
-    # Determine actual PR commit for reporting status and Docker image tagging
-    git_commit_parents="${GIT_COMMIT_PARENTS:-$(echo "${git_commit}" | git log --pretty=%P -n 1 --date-order)}"
-
-    if [ "${#git_commit_parents}" -gt 40 ]; then
-      # More than one merge commit parent signifies that the merge commit is not the PR commit
-      git_commit="${git_commit_parents:0:40}"
-    # else only one merge commit parent signifies that the merge commit is also the PR commit
+    pr_commit="$(get-pr-commit "${repo_name}" "${git_commit}")"
+    if [ -n "${pr_commit}" ]; then
+      git_commit="${pr_commit}"
     fi
   fi
   echo "${git_commit}"
+}
+
+get-pr-commit() {
+  repo_name="${1}"
+  commit="${2}"
+
+  # if pr, commit will be the merge commit with pr commit and master commit as its parents
+  # curl GH api to derive actual pr commit for reporting status and Docker image tagging
+  resp=$(curl \
+  -sSL \
+  --user deis-admin:"${GITHUB_ACCESS_TOKEN}" \
+  "https://api.github.com/repos/deis/${repo_name}/commits/${commit}")
+
+  echo "${resp}" \
+    | docker run -i --rm kamermans/jq '.commit.message' \
+    | grep -o "\(Merge\)\s[a-f0-9]*\s\(into\)" \
+    | grep -o "[a-f0-9]\{40\}"
 }

--- a/bash/tests/get_actual_commit.bats
+++ b/bash/tests/get_actual_commit.bats
@@ -4,7 +4,10 @@ setup() {
   . "${BATS_TEST_DIRNAME}/../scripts/get_actual_commit.sh"
   load stub
 
-  TEST_GIT_SHA="abc1234def567812345678901234567890123456"
+  TEST_PR_SHA="abc1234def567812345678901234567890123456"
+  TEST_MERGE_SHA="ghi1234jkl567812345678901234567890123456"
+  TEST_MASTER_SHA="mno1234pqr567812345678901234567890123456"
+  TEST_REPO_NAME="repo"
 }
 
 teardown() {
@@ -13,32 +16,41 @@ teardown() {
 
 @test "get-actual-commit : is not PR" {
   export GIT_BRANCH="origin/master"
-  export GIT_COMMIT="${TEST_GIT_SHA}"
+  export GIT_COMMIT="${TEST_MASTER_SHA}"
 
-  run get-actual-commit
+  run get-actual-commit "${TEST_REPO_NAME}"
 
   [ "${status}" -eq 0 ]
-  [ "${output}" == "${TEST_GIT_SHA}" ]
+  [ "${output}" == "${TEST_MASTER_SHA}" ]
 }
 
-@test "get-actual-commit : is PR, multiple parents" {
+@test "get-actual-commit : is PR" {
   export GIT_BRANCH="PR-123"
-  export GIT_COMMIT="${TEST_GIT_SHA}"
-  export GIT_COMMIT_PARENTS="ghi1234jkl567812345678901234567890123456 mno1234pqr567812345678901234567890123456"
+  export GIT_COMMIT="${TEST_MERGE_SHA}"
 
-  run get-actual-commit
+  curl_resp="Merge ${TEST_PR_SHA} into ${TEST_MASTER_SHA}"
 
+  load stubs/tpl/default
+  stub curl
+  stub docker "$(generate-stub "run" "${curl_resp}")" 0
+
+  run get-actual-commit "${TEST_REPO_NAME}"
+
+  echo "${output}"
   [ "${status}" -eq 0 ]
-  [ "${output}" == "ghi1234jkl567812345678901234567890123456" ]
+  [ "${output}" == "${TEST_PR_SHA}" ]
 }
 
-@test "get-actual-commit : is PR, single parent" {
+@test "get-actual-commit : is PR, use merge sha if GH API curl fails" {
   export GIT_BRANCH="PR-123"
-  export GIT_COMMIT="${TEST_GIT_SHA}"
-  export GIT_COMMIT_PARENTS="${TEST_GIT_SHA}"
+  export GIT_COMMIT="${TEST_MERGE_SHA}"
 
-  run get-actual-commit
+  stub curl "" 1
+  stub docker "" 1
 
+  run get-actual-commit "${TEST_REPO_NAME}"
+
+  echo "${output}"
   [ "${status}" -eq 0 ]
-  [ "${output}" == "${TEST_GIT_SHA}" ]
+  [ "${output}" == "${TEST_MERGE_SHA}" ]
 }

--- a/bash/tests/stubs/tpl/default.bash
+++ b/bash/tests/stubs/tpl/default.bash
@@ -1,3 +1,11 @@
+# this default stub can be used in bats tests as such:
+#
+# load stubs/tpl/default
+# stub cmd "$(generate-stub "<cmd_arg>" "<cmd_return>")"
+#
+# e.g., to stub `docker run --args` to return "foo":
+# stub docker "$(generate-stub "run" "foo")"
+
 generate-stub() {
   stub_arg="${1}"
   return_value="${2}"

--- a/jobs/component_jobs.groovy
+++ b/jobs/component_jobs.groovy
@@ -118,7 +118,7 @@ repos.each { Map repo ->
 
             ${cdComponentDir}
 
-            git_commit="\$(get-actual-commit)"
+            git_commit="\$(get-actual-commit ${repo.name})"
 
             make bootstrap || true
 


### PR DESCRIPTION
cc @helgi 

Previous logic determined the commit parents of a given merge commit (if pr) via `git` and assumed the first parent was the pr commit, based on our experience with same logic in workflow-cli/controller-sdk-go Jenkinsfiles.  Turns out, based on every PR I have since looked up GH info from, in these Jenkins jobs using the Github Pull Request Builder, the _second_ parent is the actual PR commit.  

As an alternative to this obviously faulty approach, I've changed the logic up to curl the canonical source (the GitHub API itself) and grabbing the commit message on a pr `Merge <pr_sha> into <master sha>` and deriving the actual PR commit from there.  Not sure if this is the _best_ way, but it should be an improvement.
