### PR TITLE
chore(jobs/e2e_runner.groovy): update e2e-runner job

### DIFF
--- a/jobs/e2e_runner.groovy
+++ b/jobs/e2e_runner.groovy
@@ -104,7 +104,7 @@ evaluate(new File("${WORKSPACE}/common.groovy"))
         mkdir -p ${defaults.tmpPath}
         eval \$(make image)
 
-        { echo ACTUAL_COMMIT="\$(get-actual-commit)"; \
+        { echo ACTUAL_COMMIT="\$(get-actual-commit e2e-runner)"; \
           echo E2E_RUNNER_IMAGE="\${E2E_RUNNER_IMAGE}"; \
           echo UPSTREAM_BUILD_URL="\${BUILD_URL}"; \
           echo COMPONENT_REPO="e2e-runner"; \


### PR DESCRIPTION
with proper use of `get-actual-commit`

ref https://github.com/deis/jenkins-jobs/pull/219
