### PR TITLE
feat(jobs/clusterator_jobs.groovy): no version default

### DIFF
--- a/jobs/clusterator_jobs.groovy
+++ b/jobs/clusterator_jobs.groovy
@@ -15,7 +15,7 @@ job("clusterator-create") {
     stringParam('NUMBER_OF_CLUSTERS', '10', 'Number of clusters to create at 1 time')
     stringParam('NUM_NODES', '5', 'Number of nodes in each cluster')
     stringParam('MACHINE_TYPE', 'n1-standard-4', 'Node type')
-    stringParam('VERSION', '1.2.6', 'The version of kubernetes to use.')
+    stringParam('VERSION', '', 'The version of kubernetes to use.')
   }
 
   wrappers {


### PR DESCRIPTION
Which implies clusters will be created with the latest k8s version on GKE
(1.3.5 as of this writing)

Ref https://github.com/deis/e2e-runner/pull/47 for fix enabling this change
