### PR TITLE
feat(jobs/clusterator_jobs.groovy): randomize cluster version

### DIFF
--- a/bash/scripts/clusterator_create.sh
+++ b/bash/scripts/clusterator_create.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+clusterator-create() {
+  k8s_versions="${1}"
+
+  if [ -z "${VERSION}" ]; then
+    echo "Assigning random version for each cluster based on provided list:"
+    echo "${k8s_versions}"
+  fi
+
+  clusters_created=0
+  while [ $clusters_created -lt "$NUMBER_OF_CLUSTERS" ]; do
+    cluster_version="${VERSION:-$(echo "${k8s_versions}" | shuf -n 1)}"
+    echo "Creating cluster with version: ${cluster_version}..."
+
+    docker run \
+      -e GCLOUD_CREDENTIALS="${GCLOUD_CREDENTIALS}" \
+      -e NUMBER_OF_CLUSTERS=1 \
+      -e NUM_NODES="${NUM_NODES}" \
+      -e MACHINE_TYPE="${MACHINE_TYPE}" \
+      -e VERSION="${cluster_version}" \
+      quay.io/deisci/clusterator:git-b1810a5 create
+
+    (( clusters_created += 1 ))
+  done
+}

--- a/bash/tests/clusterator_create_test.bats
+++ b/bash/tests/clusterator_create_test.bats
@@ -1,0 +1,49 @@
+#!/usr/bin/env bats
+
+setup() {
+  . "${BATS_TEST_DIRNAME}/../scripts/clusterator_create.sh"
+  load stub
+  stub docker
+}
+
+teardown() {
+  rm_stubs
+}
+
+strip-indent() {
+  echo "${1}" | sed 's/^[ \t]*//'
+}
+
+@test "clusterator-create : VERSION set" {
+  NUMBER_OF_CLUSTERS=2
+  VERSION=1.2.3
+
+  run clusterator-create ""
+
+  expected_output="\
+    Creating cluster with version: 1.2.3...
+    Creating cluster with version: 1.2.3..."
+
+  [ "${status}" -eq 0 ]
+  [ "${output}" == "$(strip-indent "${expected_output}")" ]
+}
+
+@test "clusterator-create : VERSION not set" {
+  NUMBER_OF_CLUSTERS=1
+  k8s_versions="\
+    1.2.6
+    1.3.4
+    1.3.5"
+
+  stub shuf "echo random_version"
+
+  run clusterator-create "$(strip-indent "${k8s_versions}")"
+
+  expected_output="\
+    Assigning random version for each cluster based on provided list:
+    ${k8s_versions}
+    Creating cluster with version: random_version..."
+
+  [ "${status}" -eq 0 ]
+  [ "${output}" == "$(strip-indent "${expected_output}")" ]
+}

--- a/common.groovy
+++ b/common.groovy
@@ -36,6 +36,11 @@ defaults = [
     username: 'deis-admin',
     credentialsID: '8e11254f-44f3-4ddd-bf98-2cabcb7434cd',
   ],
+  k8sClusterVersions: [
+    '1.2.6',
+    '1.3.4',
+    '1.3.5',
+  ].join('\n'),
 ]
 
 e2eRunnerJob = new File("${WORKSPACE}/bash/scripts/run_e2e.sh").text +

--- a/jobs/clusterator_jobs.groovy
+++ b/jobs/clusterator_jobs.groovy
@@ -27,18 +27,8 @@ job("clusterator-create") {
   }
 
   steps {
-    shell """
-      #!/usr/bin/env bash
-
-      set -eo pipefail
-      docker run \
-      -e GCLOUD_CREDENTIALS="\${GCLOUD_CREDENTIALS}" \
-      -e NUMBER_OF_CLUSTERS="\${NUMBER_OF_CLUSTERS}" \
-      -e NUM_NODES="\${NUM_NODES}" \
-      -e MACHINE_TYPE="\${MACHINE_TYPE}" \
-      -e VERSION="\${VERSION}" \
-      quay.io/deisci/clusterator:git-b1810a5 create
-    """.stripIndent().trim()
+    shell new File("${WORKSPACE}/bash/scripts/clusterator_create.sh").text +
+      "clusterator-create ${defaults.k8sClusterVersions}"
   }
 }
 


### PR DESCRIPTION
If VERSION is not set/empty, randomize each created cluster version based on default list provided.

ci/e2e will then be testing on a variety of k8s/GKE versions as the default day-to-day.
