### PR TITLE
ref(*): add charts and workflow-cli repos to list

### DIFF
--- a/jobs/component_jobs.groovy
+++ b/jobs/component_jobs.groovy
@@ -1,177 +1,179 @@
 evaluate(new File("${WORKSPACE}/common.groovy"))
 
 repos.each { Map repo ->
-  [
-    // for each repo, create a <repo.name>-master and <repo.name>-pr job
-    [type: 'master'],
-    [type: 'pr'],
-  ].each { Map config ->
-    isMaster = config.type == 'master'
-    isPR = config.type == 'pr'
+  if(repo.buildJobs != false) {
+    [
+      // for each repo, create a <repo.name>-master and <repo.name>-pr job
+      [type: 'master'],
+      [type: 'pr'],
+    ].each { Map config ->
+      isMaster = config.type == 'master'
+      isPR = config.type == 'pr'
 
-    name = isMaster ? repo.name : "${repo.name}-pr"
-    downstreamJobName = defaults.testJob[config.type]
+      name = isMaster ? repo.name : "${repo.name}-pr"
+      downstreamJobName = defaults.testJob[config.type]
 
-    job(name) {
-      description """
-        <ol>
-          <li>Watches the ${repo.name} repo for a ${config.type} commit</li>
-          <li>Kicks off downstream ${downstreamJobName} job to vet changes</li>
-        </ol>
-      """.stripIndent().trim()
+      job(name) {
+        description """
+          <ol>
+            <li>Watches the ${repo.name} repo for a ${config.type} commit</li>
+            <li>Kicks off downstream ${downstreamJobName} job to vet changes</li>
+          </ol>
+        """.stripIndent().trim()
 
-      scm {
-        git {
-          remote {
-            github("deis/${repo.name}")
-            credentials('597819a0-b0b9-4974-a79b-3a5c2322606d')
-            if (isPR) {
-              refspec('+refs/pull/*:refs/remotes/origin/pr/*')
+        scm {
+          git {
+            remote {
+              github("deis/${repo.name}")
+              credentials('597819a0-b0b9-4974-a79b-3a5c2322606d')
+              if (isPR) {
+                refspec('+refs/pull/*:refs/remotes/origin/pr/*')
+              }
             }
+            branch('${sha1}')
           }
-          branch('${sha1}')
         }
-      }
 
-      publishers {
-        slackNotifications {
-          notifyFailure()
-          notifyRepeatedFailure()
+        publishers {
+          slackNotifications {
+            notifyFailure()
+            notifyRepeatedFailure()
+           }
          }
-       }
 
-      if (isPR) {
-        concurrentBuild()
-        throttleConcurrentBuilds {
-          maxPerNode(defaults.maxBuildsPerNode)
-          maxTotal(defaults.maxTotalConcurrentBuilds)
-        }
-      }
-
-      logRotator {
-        daysToKeep defaults.daysToKeep
-      }
-
-      if (isPR) { // set up GitHubPullRequest build trigger
-        triggers {
-          pullRequest {
-            admin('deis-admin')
-            cron('H/5 * * * *')
-            useGitHubHooks()
-            triggerPhrase('OK to test')
-            orgWhitelist(['deis'])
-            allowMembersOfWhitelistedOrgsAsAdmin()
-            // this plugin will update PR status no matter what,
-            // so until we fix this, here are our default messages:
-            extensions {
-              commitStatus {
-                context('ci/jenkins/pr')
-                triggeredStatus("Triggering ${repo.name} build/deploy...")
-                startedStatus("Starting ${repo.name} build/deploy...")
-                completedStatus('SUCCESS', "Merge with caution! Test job(s) may still be in progress...")
-                completedStatus('FAILURE', 'Build/deploy returned failure(s).')
-                completedStatus('ERROR', 'Something went wrong.')
-              }
-            }
+        if (isPR) {
+          concurrentBuild()
+          throttleConcurrentBuilds {
+            maxPerNode(defaults.maxBuildsPerNode)
+            maxTotal(defaults.maxTotalConcurrentBuilds)
           }
         }
-      }
 
-      parameters {
-        stringParam('DOCKER_USERNAME', 'deisbot', 'Docker Hub account name')
-        stringParam('DOCKER_EMAIL', 'dummy-address@deis.com', 'Docker Hub email address')
-        stringParam('QUAY_USERNAME', 'deisci+jenkins', 'Quay account name')
-        stringParam('QUAY_EMAIL', 'deisci+jenkins@deis.com', 'Quay email address')
-        stringParam('sha1', 'master', 'Specific Git SHA to test')
-      }
-
-      triggers {
-        githubPush()
-      }
-
-      wrappers {
-        timestamps()
-        colorizeOutput 'xterm'
-        credentialsBinding {
-          string("DOCKER_PASSWORD", "0d1f268f-407d-4cd9-a3c2-0f9671df0104")
-          string("QUAY_PASSWORD", "c67dc0a1-c8c4-4568-a73d-53ad8530ceeb")
-          string("GITHUB_ACCESS_TOKEN", defaults.github.credentialsID)
-        }
-      }
-
-      steps {
-        main = [
-          new File("${WORKSPACE}/bash/scripts/get_actual_commit.sh").text,
-          new File("${WORKSPACE}/bash/scripts/find_required_commits.sh").text,
-          new File("${WORKSPACE}/bash/scripts/skip_e2e_check.sh").text,
-        ].join('\n')
-
-        repo.components.each{ Map component ->
-          cdComponentDir = component.name == repo.name ?: "cd ${component.name}"
-          dockerPush = isPR ? 'docker-immutable-push' : 'docker-push'
-
-          script = main
-          script += """
-            #!/usr/bin/env bash
-
-            set -eo pipefail
-
-            ${cdComponentDir}
-
-            git_commit="\$(get-actual-commit ${repo.name})"
-
-            make bootstrap || true
-
-            export IMAGE_PREFIX=deisci VERSION="git-\${git_commit:0:7}"
-            docker login -e="\$DOCKER_EMAIL" -u="\$DOCKER_USERNAME" -p="\$DOCKER_PASSWORD"
-            DEIS_REGISTRY='' make docker-build ${dockerPush}
-            docker login -e="\$QUAY_EMAIL" -u="\$QUAY_USERNAME" -p="\$QUAY_PASSWORD" quay.io
-            DEIS_REGISTRY=quay.io/ make docker-build ${dockerPush}
-
-            # populate env file for passing to downstream job
-            mkdir -p ${defaults.tmpPath}
-            { echo COMMIT_AUTHOR_EMAIL="\$(echo "\${git_commit}" | git --no-pager show -s --format='%ae')"; \
-              echo ACTUAL_COMMIT="\${git_commit}"; \
-              echo ${repo.commitEnvVar}="\${git_commit}"; \
-              echo "\$(find-required-commits "\${git_commit}")"; \
-              echo "\$(check-skip-e2e "\${git_commit}")"; } > ${defaults.envFile}
-          """.stripIndent().trim()
-
-          shell script
+        logRotator {
+          daysToKeep defaults.daysToKeep
         }
 
-        if (repo.runE2e) {
-          conditionalSteps {
-            condition {
-              not {
-                shell "cat \"${defaults.envFile}\" | grep -q SKIP_E2E"
-              }
-            }
-            steps {
-              downstreamParameterized {
-                trigger(downstreamJobName) {
-                  parameters {
-                    propertiesFile(defaults.envFile)
-                    predefinedProps([
-                      'UPSTREAM_BUILD_URL': '${BUILD_URL}',
-                      'UPSTREAM_SLACK_CHANNEL': "${repo.slackChannel}",
-                      'COMPONENT_REPO': "${repo.name}",
-                    ])
-                  }
+        if (isPR) { // set up GitHubPullRequest build trigger
+          triggers {
+            pullRequest {
+              admin('deis-admin')
+              cron('H/5 * * * *')
+              useGitHubHooks()
+              triggerPhrase('OK to test')
+              orgWhitelist(['deis'])
+              allowMembersOfWhitelistedOrgsAsAdmin()
+              // this plugin will update PR status no matter what,
+              // so until we fix this, here are our default messages:
+              extensions {
+                commitStatus {
+                  context('ci/jenkins/pr')
+                  triggeredStatus("Triggering ${repo.name} build/deploy...")
+                  startedStatus("Starting ${repo.name} build/deploy...")
+                  completedStatus('SUCCESS', "Merge with caution! Test job(s) may still be in progress...")
+                  completedStatus('FAILURE', 'Build/deploy returned failure(s).')
+                  completedStatus('ERROR', 'Something went wrong.')
                 }
               }
             }
           }
-        } else {
-          if (isMaster) {
-            repo.components.each{ Map component ->
-              downstreamParameterized {
-                trigger('component-promote') {
-                  parameters {
-                    predefinedProps([
-                      'COMPONENT_NAME': component.name,
-                      'COMPONENT_SHA': '${GIT_COMMIT}',
-                    ])
+        }
+
+        parameters {
+          stringParam('DOCKER_USERNAME', 'deisbot', 'Docker Hub account name')
+          stringParam('DOCKER_EMAIL', 'dummy-address@deis.com', 'Docker Hub email address')
+          stringParam('QUAY_USERNAME', 'deisci+jenkins', 'Quay account name')
+          stringParam('QUAY_EMAIL', 'deisci+jenkins@deis.com', 'Quay email address')
+          stringParam('sha1', 'master', 'Specific Git SHA to test')
+        }
+
+        triggers {
+          githubPush()
+        }
+
+        wrappers {
+          timestamps()
+          colorizeOutput 'xterm'
+          credentialsBinding {
+            string("DOCKER_PASSWORD", "0d1f268f-407d-4cd9-a3c2-0f9671df0104")
+            string("QUAY_PASSWORD", "c67dc0a1-c8c4-4568-a73d-53ad8530ceeb")
+            string("GITHUB_ACCESS_TOKEN", defaults.github.credentialsID)
+          }
+        }
+
+        steps {
+          main = [
+            new File("${WORKSPACE}/bash/scripts/get_actual_commit.sh").text,
+            new File("${WORKSPACE}/bash/scripts/find_required_commits.sh").text,
+            new File("${WORKSPACE}/bash/scripts/skip_e2e_check.sh").text,
+          ].join('\n')
+
+          repo.components.each{ Map component ->
+            cdComponentDir = component.name == repo.name ?: "cd ${component.name}"
+            dockerPush = isPR ? 'docker-immutable-push' : 'docker-push'
+
+            script = main
+            script += """
+              #!/usr/bin/env bash
+
+              set -eo pipefail
+
+              ${cdComponentDir}
+
+              git_commit="\$(get-actual-commit ${repo.name})"
+
+              make bootstrap || true
+
+              export IMAGE_PREFIX=deisci VERSION="git-\${git_commit:0:7}"
+              docker login -e="\$DOCKER_EMAIL" -u="\$DOCKER_USERNAME" -p="\$DOCKER_PASSWORD"
+              DEIS_REGISTRY='' make docker-build ${dockerPush}
+              docker login -e="\$QUAY_EMAIL" -u="\$QUAY_USERNAME" -p="\$QUAY_PASSWORD" quay.io
+              DEIS_REGISTRY=quay.io/ make docker-build ${dockerPush}
+
+              # populate env file for passing to downstream job
+              mkdir -p ${defaults.tmpPath}
+              { echo COMMIT_AUTHOR_EMAIL="\$(echo "\${git_commit}" | git --no-pager show -s --format='%ae')"; \
+                echo ACTUAL_COMMIT="\${git_commit}"; \
+                echo ${repo.commitEnvVar}="\${git_commit}"; \
+                echo "\$(find-required-commits "\${git_commit}")"; \
+                echo "\$(check-skip-e2e "\${git_commit}")"; } > ${defaults.envFile}
+            """.stripIndent().trim()
+
+            shell script
+          }
+
+          if (repo.runE2e) {
+            conditionalSteps {
+              condition {
+                not {
+                  shell "cat \"${defaults.envFile}\" | grep -q SKIP_E2E"
+                }
+              }
+              steps {
+                downstreamParameterized {
+                  trigger(downstreamJobName) {
+                    parameters {
+                      propertiesFile(defaults.envFile)
+                      predefinedProps([
+                        'UPSTREAM_BUILD_URL': '${BUILD_URL}',
+                        'UPSTREAM_SLACK_CHANNEL': "${repo.slackChannel}",
+                        'COMPONENT_REPO': "${repo.name}",
+                      ])
+                    }
+                  }
+                }
+              }
+            }
+          } else {
+            if (isMaster) {
+              repo.components.each{ Map component ->
+                downstreamParameterized {
+                  trigger('component-promote') {
+                    parameters {
+                      predefinedProps([
+                        'COMPONENT_NAME': component.name,
+                        'COMPONENT_SHA': '${GIT_COMMIT}',
+                      ])
+                    }
                   }
                 }
               }

--- a/jobs/component_release.groovy
+++ b/jobs/component_release.groovy
@@ -1,83 +1,108 @@
 evaluate(new File("${WORKSPACE}/common.groovy"))
 
 repos.each { Map repo ->
-  name = "${repo.name}-release"
+  if(repo.buildJobs != false) {
+    name = "${repo.name}-release"
 
-  job(name) {
-    description """
-      <ol>
-        <li>Watches the ${repo.name} repo for a git tag push. (It can also be triggered manually, supplying a value for TAG.)</li>
-        <li>Unless TAG is set (manual trigger), this job only runs off the latest tag.</li>
-        <li>The commit at HEAD of tag is then used to locate the release candidate image(s).</li>
-        <li>Kicks off downstream e2e job to vet candidate image(s).</li>
-        <li>Provided e2e tests pass, retags release candidate(s) with official semver tag in the 'deis' registry orgs.</li>
-      </ol>
-    """.stripIndent().trim()
+    job(name) {
+      description """
+        <ol>
+          <li>Watches the ${repo.name} repo for a git tag push. (It can also be triggered manually, supplying a value for TAG.)</li>
+          <li>Unless TAG is set (manual trigger), this job only runs off the latest tag.</li>
+          <li>The commit at HEAD of tag is then used to locate the release candidate image(s).</li>
+          <li>Kicks off downstream e2e job to vet candidate image(s).</li>
+          <li>Provided e2e tests pass, retags release candidate(s) with official semver tag in the 'deis' registry orgs.</li>
+        </ol>
+      """.stripIndent().trim()
 
-    scm {
-      git {
-        remote {
-          github("deis/${repo.name}")
-          credentials('597819a0-b0b9-4974-a79b-3a5c2322606d')
-          refspec('+refs/tags/*:refs/remotes/origin/tags/*')
+      scm {
+        git {
+          remote {
+            github("deis/${repo.name}")
+            credentials('597819a0-b0b9-4974-a79b-3a5c2322606d')
+            refspec('+refs/tags/*:refs/remotes/origin/tags/*')
+          }
+          branch('*/tags/*')
         }
-        branch('*/tags/*')
       }
-    }
 
-    logRotator {
-      daysToKeep defaults.daysToKeep
-    }
+      logRotator {
+        daysToKeep defaults.daysToKeep
+      }
 
-    publishers {
-      slackNotifications {
-        notifyFailure()
-        notifyRepeatedFailure()
+      publishers {
+        slackNotifications {
+          notifyFailure()
+          notifyRepeatedFailure()
+         }
        }
-     }
 
-    parameters {
-      stringParam('TAG', '', 'Specific tag to release')
-    }
-
-    triggers {
-      githubPush()
-    }
-
-    wrappers {
-      buildName('${GIT_BRANCH} ${TAG} #${BUILD_NUMBER}')
-      timestamps()
-      colorizeOutput 'xterm'
-    }
-
-    steps {
-      main = [
-        new File("${WORKSPACE}/bash/scripts/get_latest_tag.sh").text,
-        new File("${WORKSPACE}/bash/scripts/locate_release_candidate.sh").text,
-      ].join('\n')
-
-      repo.components.each{ Map component ->
-        main += """
-          #!/usr/bin/env bash
-
-          set -eo pipefail
-
-          tag="\$(get-latest-tag)"
-          commit="\$(git checkout "\${tag}" && git rev-parse HEAD)"
-          echo "Checked out tag '\${tag}' and will pass commit at HEAD (\${commit}) to downstream job."
-
-          echo "Locating release candidate based on tag commit '\${commit}'..."
-          result="\$(locate-release-candidate ${component.name} "\${commit}" "\${tag}")"
-
-          mkdir -p "\$(dirname ${component.envFile})"
-          echo "\${result}" >> ${component.envFile}
-
-        """.stripIndent()
+      parameters {
+        stringParam('TAG', '', 'Specific tag to release')
       }
 
-      shell main
+      triggers {
+        githubPush()
+      }
 
-      if (repo.runE2e) {
+      wrappers {
+        buildName('${GIT_BRANCH} ${TAG} #${BUILD_NUMBER}')
+        timestamps()
+        colorizeOutput 'xterm'
+      }
+
+      steps {
+        main = [
+          new File("${WORKSPACE}/bash/scripts/get_latest_tag.sh").text,
+          new File("${WORKSPACE}/bash/scripts/locate_release_candidate.sh").text,
+        ].join('\n')
+
+        repo.components.each{ Map component ->
+          main += """
+            #!/usr/bin/env bash
+
+            set -eo pipefail
+
+            tag="\$(get-latest-tag)"
+            commit="\$(git checkout "\${tag}" && git rev-parse HEAD)"
+            echo "Checked out tag '\${tag}' and will pass commit at HEAD (\${commit}) to downstream job."
+
+            echo "Locating release candidate based on tag commit '\${commit}'..."
+            result="\$(locate-release-candidate ${component.name} "\${commit}" "\${tag}")"
+
+            mkdir -p "\$(dirname ${component.envFile})"
+            echo "\${result}" >> ${component.envFile}
+
+          """.stripIndent()
+        }
+
+        shell main
+
+        if (repo.runE2e) {
+          conditionalSteps {
+            condition {
+              status('SUCCESS', 'SUCCESS')
+            }
+            steps {
+              repo.components.each{ Map component ->
+                downstreamParameterized {
+                  trigger('release-candidate-e2e') {
+                    block {
+                      buildStepFailure('FAILURE')
+                      failure('FAILURE')
+                      unstable('UNSTABLE')
+                    }
+                    parameters {
+                      propertiesFile(component.envFile)
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+
+        // If e2e job results in `SUCCESS`, promote release candidate
         conditionalSteps {
           condition {
             status('SUCCESS', 'SUCCESS')
@@ -85,7 +110,7 @@ repos.each { Map repo ->
           steps {
             repo.components.each{ Map component ->
               downstreamParameterized {
-                trigger('release-candidate-e2e') {
+                trigger('release-candidate-promote') {
                   block {
                     buildStepFailure('FAILURE')
                     failure('FAILURE')
@@ -94,29 +119,6 @@ repos.each { Map repo ->
                   parameters {
                     propertiesFile(component.envFile)
                   }
-                }
-              }
-            }
-          }
-        }
-      }
-
-      // If e2e job results in `SUCCESS`, promote release candidate
-      conditionalSteps {
-        condition {
-          status('SUCCESS', 'SUCCESS')
-        }
-        steps {
-          repo.components.each{ Map component ->
-            downstreamParameterized {
-              trigger('release-candidate-promote') {
-                block {
-                  buildStepFailure('FAILURE')
-                  failure('FAILURE')
-                  unstable('UNSTABLE')
-                }
-                parameters {
-                  propertiesFile(component.envFile)
                 }
               }
             }

--- a/jobs/workflow_test.groovy
+++ b/jobs/workflow_test.groovy
@@ -91,8 +91,6 @@ import utilities.StatusUpdater
       repos.each { Map repo ->
         stringParam(repo.commitEnvVar, '', "${repo.name} commit SHA")
       }
-      stringParam('CHARTS_SHA', '', "charts commit SHA")
-      stringParam('WORKFLOW_CLI_SHA', '', "workflow-cli commit SHA")
       stringParam('UPSTREAM_BUILD_URL', '', "Upstream build url")
       stringParam('UPSTREAM_SLACK_CHANNEL', '', "Upstream Slack channel")
       stringParam('COMPONENT_REPO', '', "Component repo name")

--- a/repo.groovy
+++ b/repo.groovy
@@ -4,6 +4,14 @@ repos = [
     slackChannel: 'builder',
     runE2e: true],
 
+  [ name: 'charts',
+    buildJobs: false],
+
+  [ name: 'controller',
+    components: [[name: 'controller']],
+    slackChannel: 'controller',
+    runE2e: true],
+
   [ name: 'dockerbuilder',
     components: [[name: 'dockerbuilder']],
     slackChannel: 'builder',
@@ -69,10 +77,8 @@ repos = [
     slackChannel: 'builder',
     runE2e: true],
 
-  [ name: 'controller',
-    components: [[name: 'controller']],
-    slackChannel: 'controller',
-    runE2e: true],
+  [ name: 'workflow-cli',
+    buildJobs: false],
 
   [ name: 'workflow-e2e',
     components: [[name: 'workflow-e2e']],


### PR DESCRIPTION
But with `buildJobs` bool set to `false`.  Meaning, don't build jobs for them
like the other Workflow components, but do create env vars based on commit
shas for use in other jobs.

(note the only changes in `component_jobs.groovy` and `component_release.groovy` is the check for `repo.buildJobs != false` and resulting indentation of body, contrary to what GH seems to be presenting here.)
