### PR TITLE
fix(bash/scripts/get_actual_commit.sh): inspect ghprbActualCommit

### DIFF
--- a/bash/tests/get_actual_commit_test.bats
+++ b/bash/tests/get_actual_commit_test.bats
@@ -24,7 +24,21 @@ teardown() {
   [ "${output}" == "${TEST_MASTER_SHA}" ]
 }
 
-@test "get-actual-commit : is PR" {
+@test "get-actual-commit : is PR, ghprbActualCommit defined" {
+  export GIT_BRANCH="PR-123"
+  export GIT_COMMIT="${TEST_MERGE_SHA}"
+  export ghprbActualCommit="${TEST_PR_SHA}"
+
+  # don't stub curl or jq as logic should not use them
+  # (test will fail if either binary is invoked)
+
+  run get-actual-commit "${TEST_REPO_NAME}" "${ghprbActualCommit}"
+
+  [ "${status}" -eq 0 ]
+  [ "${output}" == "${TEST_PR_SHA}" ]
+}
+
+@test "get-actual-commit : is PR, ghprbActualCommit not defined" {
   export GIT_BRANCH="PR-123"
   export GIT_COMMIT="${TEST_MERGE_SHA}"
 
@@ -39,7 +53,7 @@ teardown() {
   [ "${output}" == "${TEST_PR_SHA}" ]
 }
 
-@test "get-actual-commit : is PR, use merge sha if GH API curl fails" {
+@test "get-actual-commit : is PR, ghprbActualCommit not defined, use merge sha if GH API curl fails" {
   export GIT_BRANCH="PR-123"
   export GIT_COMMIT="${TEST_MERGE_SHA}"
 

--- a/jobs/component_jobs.groovy
+++ b/jobs/component_jobs.groovy
@@ -119,7 +119,7 @@ repos.each { Map repo ->
 
               ${cdComponentDir}
 
-              git_commit="\$(get-actual-commit ${repo.name})"
+              git_commit="\$(get-actual-commit ${repo.name} \${ghprbActualCommit})"
 
               make bootstrap || true
 

--- a/jobs/e2e_runner.groovy
+++ b/jobs/e2e_runner.groovy
@@ -104,7 +104,7 @@ evaluate(new File("${WORKSPACE}/common.groovy"))
         mkdir -p ${defaults.tmpPath}
         eval \$(make image)
 
-        { echo ACTUAL_COMMIT="\$(get-actual-commit e2e-runner)"; \
+        { echo ACTUAL_COMMIT="\$(get-actual-commit e2e-runner \${ghprbActualCommit})"; \
           echo E2E_RUNNER_IMAGE="\${E2E_RUNNER_IMAGE}"; \
           echo UPSTREAM_BUILD_URL="\${BUILD_URL}"; \
           echo COMPONENT_REPO="e2e-runner"; \


### PR DESCRIPTION
We'd previously tried not to rely on the environment for getting actual PR commits
(specifically, avoiding depending on the `ghprbActualCommit` env var provided by the GitHub Pull Request Builder Plugin) and instead invoked the `git` cli and/or curled the GitHub API directly, as a general practice of reducing dependencies on plugin code as well as increasing portability between jobs defined in DSL here and in Jenkinsfile logic, etc.

Blah, blah, blah, anyways, since we _are_ still using the ghprb plugin, and we've seen [issues](https://github.com/deis/jenkins-jobs/issues/227) with solely relying on the GitHub API, this change brings back logic to defer to the `ghprbActualCommit` env var, when present, as the PR commit for building artifacts and updating statuses. (We'll still curl the api as a backup if not present.)

Closes https://github.com/deis/jenkins-jobs/issues/227
