### PR TITLE
fix(*): decouple Workflow (chart) and Workflow CLI release values

### DIFF
--- a/common.groovy
+++ b/common.groovy
@@ -1,16 +1,19 @@
 evaluate(new File("${WORKSPACE}/repo.groovy"))
 
-WORKFLOW_RELEASE = 'v2.4.2'
-TEST_JOB_ROOT_NAME = 'workflow-test'
+def workflowRelease = [
+  chart: 'v2.4.2',
+  cli: 'v2.4.0',
+]
+def testJobRootName = 'workflow-test'
 
 defaults = [
   tmpPath: '/tmp/${JOB_NAME}/${BUILD_NUMBER}',
   envFile: '/tmp/${JOB_NAME}/${BUILD_NUMBER}/env.properties',
   daysToKeep: 14,
   testJob: [
-    master: "${TEST_JOB_ROOT_NAME}",
-    pr: "${TEST_JOB_ROOT_NAME}-pr",
-    release: "${TEST_JOB_ROOT_NAME}-release",
+    master: testJobRootName,
+    pr: "${testJobRootName}-pr",
+    release: "${testJobRootName}-release",
     reportMsg: "Test Report: ${JENKINS_URL}job/\${JOB_NAME}/\${BUILD_NUMBER}/testReport",
     timeoutMins: 30,
   ],
@@ -21,7 +24,10 @@ defaults = [
   maxWorkflowReleaseConcurrentBuilds: 1,
   workflow: [
     chartName: 'workflow-dev',
-    release: "${WORKFLOW_RELEASE}",
+    release: workflowRelease.chart,
+  ],
+  cli: [
+    release: workflowRelease.cli,
   ],
   slack: [
     teamDomain: 'deis',

--- a/jobs/component_release.groovy
+++ b/jobs/component_release.groovy
@@ -39,6 +39,7 @@ repos.each { Map repo ->
 
       parameters {
         stringParam('TAG', '', 'Specific tag to release')
+        stringParam('CLI_VERSION', defaults.cli.release, 'Specific Workflow CLI version to use in downstream e2e run, if applicable')
       }
 
       triggers {
@@ -71,8 +72,8 @@ repos.each { Map repo ->
             result="\$(locate-release-candidate ${component.name} "\${commit}" "\${tag}")"
 
             mkdir -p "\$(dirname ${component.envFile})"
-            echo "\${result}" >> ${component.envFile}
-
+            { echo "\${result}"; \
+              echo "CLI_VERSION=\${CLI_VERSION}"; } >> ${component.envFile}
           """.stripIndent()
         }
 

--- a/jobs/release_candidate_e2e.groovy
+++ b/jobs/release_candidate_e2e.groovy
@@ -38,7 +38,7 @@ job(name) {
     repos.each { Map repo ->
       stringParam(repo.commitEnvVar, '', "${repo.name} commit SHA")
     }
-    stringParam('CLI_VERSION', defaults.workflow.release, "workflow-cli version")
+    stringParam('CLI_VERSION', '', "Specific Workflow CLI version")
     stringParam('WORKFLOW_BRANCH', "release-${defaults.workflow.release}", "The branch to use for installing the workflow chart.")
     stringParam('WORKFLOW_E2E_BRANCH', "release-${defaults.workflow.release}", "The branch to use for installing the workflow-e2e chart.")
     stringParam('RELEASE', defaults.workflow.release, "Release string for resolving workflow-[release](-e2e) charts")


### PR DESCRIPTION
Can now specify the CLI release value in the initial job of a component's release pipeline, for use downstream.

Also change groovy 'constants' from screaming snake case to groovy-er camel case, to avoid confusing with bash constants.

TODO (post-lgtm)
- [ ] follow-up PR in appropriate release doc to update `CLI_RELEASE` when CLI is released.

cc @jchauncey 
