### PR TITLE
ref(workflow_cli_release.groovy): trigger multiple downstream jobs

### DIFF
--- a/common.groovy
+++ b/common.groovy
@@ -1,9 +1,6 @@
 evaluate(new File("${WORKSPACE}/repo.groovy"))
 
-def workflowRelease = [
-  chart: 'v2.5.0',
-  cli: 'v2.5.1',
-]
+def workflowChartRelease = 'v2.5.0'
 def testJobRootName = 'workflow-test'
 
 defaults = [
@@ -24,10 +21,10 @@ defaults = [
   maxWorkflowReleaseConcurrentBuilds: 1,
   workflow: [
     chartName: 'workflow-dev',
-    release: workflowRelease.chart,
+    release: workflowChartRelease,
   ],
   cli: [
-    release: workflowRelease.cli,
+    release: 'stable',
   ],
   slack: [
     teamDomain: 'deis',

--- a/jobs/workflow_cli_release.groovy
+++ b/jobs/workflow_cli_release.groovy
@@ -1,6 +1,24 @@
 evaluate(new File("${WORKSPACE}/common.groovy"))
 
-repoName="workflow-cli"
+def repoName = 'workflow-cli'
+
+def gitInfo = [
+  repo: "deis/${repoName}",
+  creds: '597819a0-b0b9-4974-a79b-3a5c2322606d',
+  refspec: '+refs/tags/*:refs/remotes/origin/tags/*',
+  branch: '*/tags/*',
+]
+
+def downstreamJobs = [
+  [
+    name: "${repoName}-build-tag",
+    target: 'build-tag',
+  ],
+  [
+    name: "${repoName}-build-stable",
+    target: 'build-stable',
+  ],
+]
 
 job("${repoName}-release") {
   description """
@@ -11,11 +29,11 @@ job("${repoName}-release") {
   scm {
     git {
       remote {
-        github("deis/${repoName}")
-        credentials('597819a0-b0b9-4974-a79b-3a5c2322606d')
-        refspec('+refs/tags/*:refs/remotes/origin/tags/*')
+        github(gitInfo.repo)
+        credentials(gitInfo.creds)
+        refspec(gitInfo.refspec)
       }
-      branch('*/tags/*')
+      branch(gitInfo.branch)
     }
   }
 
@@ -42,38 +60,94 @@ job("${repoName}-release") {
     buildName('${GIT_BRANCH} ${TAG} #${BUILD_NUMBER}')
     timestamps()
     colorizeOutput 'xterm'
-    credentialsBinding {
-      string("GCSKEY", "6561701c-b7b4-4796-83c4-9d87946799e4")
-    }
   }
 
   steps {
-    def bucket = "gs://workflow-cli-release"
+    shell new File("${WORKSPACE}/bash/scripts/get_latest_tag.sh").text +
+      """
+        mkdir -p ${defaults.tmpPath}
+        echo TAG="\$(get-latest-tag)" > ${defaults.envFile}
+      """.stripIndent().trim()
 
-    def headers  = "-h 'x-goog-meta-ci-job:\${JOB_NAME}' "
-        headers += "-h 'x-goog-meta-ci-number:\${BUILD_NUMBER}' "
-        headers += "-h 'x-goog-meta-ci-url:\${BUILD_URL}'"
+    downstreamParameterized {
+      // For now, only kick off the 'build-tag' variant
+      trigger('workflow-cli-build-tag') {
+        block {
+          buildStepFailure('FAILURE')
+          failure('FAILURE')
+          unstable('UNSTABLE')
+        }
+        parameters {
+          propertiesFile(defaults.envFile)
+        }
+      }
+    }
+  }
+}
 
-    def script  = "sh -c 'make build-tag "
-        script += "&& echo \${GCS_KEY_JSON} | base64 -d - > /tmp/key.json "
-        script += "&& gcloud auth activate-service-account -q --key-file /tmp/key.json "
-        script += "&& gsutil -mq ${headers} cp -a public-read -r _dist/* ${bucket}'"
+downstreamJobs.each{ Map thisJob ->
+  job(thisJob.name) {
+    scm {
+      git {
+        remote {
+          github(gitInfo.repo)
+          credentials(gitInfo.creds)
+          refspec(gitInfo.refspec)
+        }
+        branch(gitInfo.branch)
+      }
+    }
 
-    main = new File("${WORKSPACE}/bash/scripts/get_latest_tag.sh").text
+    publishers {
+      slackNotifications {
+        notifyFailure()
+        notifyRepeatedFailure()
+      }
+    }
 
-    main += """
-      #!/usr/bin/env bash
+    logRotator {
+      daysToKeep defaults.daysToKeep
+    }
 
-      set -eo pipefail
+    parameters {
+      stringParam('TAG', '', 'Specific tag to release')
+    }
 
-      tag="\$(get-latest-tag)"
-      git_commit="\$(git checkout "\${tag}" && git rev-parse HEAD)"
-      revision_image=quay.io/deisci/workflow-cli-dev:"\${git_commit:0:7}"
+    wrappers {
+      buildName("\${TAG} #\${BUILD_NUMBER}")
+      timestamps()
+      colorizeOutput 'xterm'
+      credentialsBinding {
+        string("GCSKEY", "6561701c-b7b4-4796-83c4-9d87946799e4")
+      }
+    }
 
-      # Build and upload artifacts
-      docker run -e GCS_KEY_JSON=\"\${GCSKEY}\" --rm "\${revision_image}" ${script}
-    """.stripIndent().trim()
+    steps {
+      def bucket = "gs://workflow-cli-release"
 
-    shell main
+      def headers  = "-h 'x-goog-meta-ci-job:\${JOB_NAME}' "
+          headers += "-h 'x-goog-meta-ci-number:\${BUILD_NUMBER}' "
+          headers += "-h 'x-goog-meta-ci-url:\${BUILD_URL}'"
+
+      def script  = "sh -c 'make ${thisJob.target} "
+          script += "&& echo \${GCS_KEY_JSON} | base64 -d - > /tmp/key.json "
+          script += "&& gcloud auth activate-service-account -q --key-file /tmp/key.json "
+          script += "&& gsutil -mq ${headers} cp -a public-read -r _dist/* ${bucket}'"
+
+      shell """
+        #!/usr/bin/env bash
+
+        set -eo pipefail
+
+        git_commit="\$(git checkout "\${TAG}" && git rev-parse HEAD)"
+        revision_image=quay.io/deisci/workflow-cli-dev:"\${git_commit:0:7}"
+
+        # Build and upload artifacts
+        docker run \
+          -e GCS_KEY_JSON=\"\${GCSKEY}\" \
+          -e GIT_TAG="\$(git describe --abbrev=0 --tags)" \
+          --rm "\${revision_image}" ${script}
+      """.stripIndent().trim()
+    }
   }
 }

--- a/jobs/workflow_test_release.groovy
+++ b/jobs/workflow_test_release.groovy
@@ -47,7 +47,7 @@ job(name) {
    }
 
   parameters {
-    stringParam('CLI_VERSION', defaults.workflow.release, "workflow-cli version")
+    stringParam('CLI_VERSION', defaults.cli.release, "workflow-cli version")
     stringParam('WORKFLOW_BRANCH', "release-${defaults.workflow.release}", "The branch to use for installing the workflow chart.")
     stringParam('WORKFLOW_E2E_BRANCH', "release-${defaults.workflow.release}", "The branch to use for installing the workflow-e2e chart.")
     stringParam('RELEASE', defaults.workflow.release, "Release string for resolving workflow-[release](-e2e) charts")


### PR DESCRIPTION
So that on a workflow-cli release event, both the immutable release artifact and updated `deis-stable` artifact
can be built/uploaded concurrently.

TODO:
- [x] test the revised job to be sure it uploads both immutable and mutable release artifacts -- we'll be doing this for the next `v2.5.0` workflow-cli release.

Ref https://github.com/deis/workflow-cli/pull/218
