### PR TITLE
fix(component_release_publish.groovy): remove git push command

### DIFF
--- a/jobs/component_release_publish.groovy
+++ b/jobs/component_release_publish.groovy
@@ -49,7 +49,6 @@ job('component-release-publish') {
     shell '''
       git add versions/${COMPONENT}/${RELEASE}.json
       git commit versions/${COMPONENT}/${RELEASE}.json -m "feat(versions): add ${COMPONENT} ${RELEASE}"
-      git push origin master
     '''.stripIndent().trim()
   }
 }


### PR DESCRIPTION
As the git publish step added in https://github.com/deis/jenkins-jobs/pull/237
now handles pushing the staged commit.
