### PR TITLE
ref(*): Notify Slack via api curl

### DIFF
--- a/bash/scripts/slack_notify.sh
+++ b/bash/scripts/slack_notify.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# slack-notify sends the provided message to the provided slack channel
+# using the incoming-webhook url expected to be defined in the job environment
+slack-notify() {
+  channel="${1}"
+  status="${2}"
+  message="${3}"
+
+  if [[ $# -lt 2 ]]; then
+    echo "Usage: slack-notify channel status [message]"
+    return 1
+  fi
+
+  title="${JOB_NAME} - ${BUILD_DISPLAY_NAME} *${status}* (<${BUILD_URL}|Open>)"
+
+  data='
+    {"channel":"'"${channel}"'",
+    "attachments": [
+      {
+        "fallback": "'"${title}"'",
+        "color": "'"$(get-status-color "${status}")"'",
+        "pretext": "'"${title}"'",
+        "text": "'"${message}"'",
+        "mrkdwn_in": ["pretext", "text"],
+        "ts": '"$(date +%s)"'
+      }
+    ]}
+  '
+
+  { echo "Notifying Slack with the following data:"; \
+    echo "${data}"; } >&2
+
+  curl \
+    -X POST -H 'Content-type: application/json' \
+    --data "${data}" \
+    "${SLACK_INCOMING_WEBHOOK_URL}"
+}
+
+get-status-color() {
+  status="${1}"
+
+  local color
+  case "$status" in
+    'SUCCESS')
+      color='good'
+      ;;
+    'FAILURE')
+      color='danger'
+      ;;
+    'ABORTED'|'UNSTABLE')
+      color='warning'
+      ;;
+    *)
+      color='#ccccff'
+      ;;
+  esac
+
+  echo "${color}"
+}

--- a/bash/tests/slack_notify_test.bats
+++ b/bash/tests/slack_notify_test.bats
@@ -1,0 +1,95 @@
+#!/usr/bin/env bats
+
+setup() {
+  . "${BATS_TEST_DIRNAME}/../scripts/slack_notify.sh"
+  load stub
+  stub curl
+
+  JOB_NAME="test-job"
+  BUILD_DISPLAY_NAME="#42"
+  BUILD_URL="test-job.url"
+}
+
+teardown() {
+  rm_stubs
+}
+
+strip-ws() {
+  echo -e "${1}" | tr -d '[[:space:]]'
+}
+
+@test "get-status-color: SUCCESS" {
+  run get-status-color "SUCCESS"
+
+  [ "${status}" -eq 0 ]
+  [ "${output}" == "good" ]
+}
+
+@test "get-status-color: FAILURE" {
+  run get-status-color "FAILURE"
+
+  [ "${status}" -eq 0 ]
+  [ "${output}" == "danger" ]
+}
+
+@test "get-status-color: ABORTED" {
+  run get-status-color "ABORTED"
+
+  [ "${status}" -eq 0 ]
+  [ "${output}" == "warning" ]
+}
+
+@test "get-status-color: UNSTABLE" {
+  run get-status-color "UNSTABLE"
+
+  [ "${status}" -eq 0 ]
+  [ "${output}" == "warning" ]
+}
+
+@test "get-status-color: no status supplied" {
+  run get-status-color
+
+  [ "${status}" -eq 0 ]
+  [ "${output}" == "#ccccff" ]
+}
+
+@test "slack-notify: default" {
+  channel="test-channel"
+  buildStatus="SUCCESS"
+  message='
+    line 1
+    line 2
+  '
+
+  expected_color='good'
+  expected_title="${JOB_NAME} - ${BUILD_DISPLAY_NAME} *${buildStatus}* (<${BUILD_URL}|Open>)"
+  expected_data='
+    {"channel":"'"${channel}"'",
+    "attachments": [
+      {
+        "fallback": "'"${expected_title}"'",
+        "color": "'"${expected_color}"'",
+        "pretext": "'"${expected_title}"'",
+        "text": "'"${message}"'",
+        "mrkdwn_in": ["pretext", "text"],
+        "ts": '"$(date +%s)"'
+      }
+    ]}
+  '
+  expected_output='
+    Notifying Slack with the following data:
+    '"${expected_data}"'
+  '
+
+  run slack-notify "${channel}" "${buildStatus}" "${message}"
+
+  [ "${status}" -eq 0 ]
+  [ "$(strip-ws "${output}")" == "$(strip-ws "${expected_output}")" ]
+}
+
+@test "slack-notify: usage" {
+  run slack-notify
+
+  [ "${status}" -eq 1 ]
+  [ "${output}" == "Usage: slack-notify channel status [message]" ]
+}

--- a/common.groovy
+++ b/common.groovy
@@ -13,7 +13,6 @@ defaults = [
     master: testJobRootName,
     pr: "${testJobRootName}-pr",
     release: "${testJobRootName}-release",
-    reportMsg: "Test Report: https://ci.deis.io/job/\${JOB_NAME}/\${BUILD_NUMBER}/testReport",
     timeoutMins: 30,
   ],
   maxBuildsPerNode: 1,
@@ -31,6 +30,7 @@ defaults = [
   slack: [
     teamDomain: 'deis',
     channel: '#testing',
+    webhookURL: 'a53b3a9e-d649-4cff-9997-6c24f07743c8',
   ],
   helm: [
     remoteRepo: 'https://github.com/deis/charts.git',

--- a/jobs/storage_test.groovy
+++ b/jobs/storage_test.groovy
@@ -37,7 +37,6 @@ job(name) {
 
   publishers {
     slackNotifications {
-      customMessage(defaults.testJob["reportMsg"])
       notifyFailure()
       includeTestSummary()
     }

--- a/jobs/workflow_test_release.groovy
+++ b/jobs/workflow_test_release.groovy
@@ -25,7 +25,6 @@ job(name) {
 
   publishers {
     slackNotifications {
-      customMessage(defaults.testJob["reportMsg"])
       notifyFailure()
       includeTestSummary()
      }

--- a/repo.groovy
+++ b/repo.groovy
@@ -1,7 +1,7 @@
 repos = [
   [ name: 'builder',
     components: [[name: 'builder']],
-    slackChannel: 'builder',
+    slackChannel: '#builder',
     runE2e: true],
 
   [ name: 'charts',
@@ -9,77 +9,77 @@ repos = [
 
   [ name: 'controller',
     components: [[name: 'controller']],
-    slackChannel: 'controller',
+    slackChannel: '#controller',
     runE2e: true],
 
   [ name: 'dockerbuilder',
     components: [[name: 'dockerbuilder']],
-    slackChannel: 'builder',
+    slackChannel: '#builder',
     runE2e: true],
 
   [ name: 'fluentd',
     components: [[name: 'fluentd']],
-    slackChannel: 'logger',
+    slackChannel: '#logger',
     runE2e: true],
 
   [ name: 'logger',
     components: [[name: 'logger']],
-    slackChannel: 'logger',
+    slackChannel: '#logger',
     runE2e: true],
 
   [ name: 'minio',
     components: [[name: 'minio']],
-    slackChannel: 'object-store',
+    slackChannel: '#object-store',
     runE2e: true],
 
   [ name: 'monitor',
     components: [[name: 'grafana'], [name: 'influxdb'], [name: 'telegraf']],
-    slackChannel: 'monitor',
+    slackChannel: '#monitor',
     runE2e: false],
 
   [ name: 'nsq',
     components: [[name: 'nsq']],
-    slackChannel: 'logger',
+    slackChannel: '#logger',
     runE2e: true],
 
   [ name: 'postgres',
     components: [[name: 'postgres']],
-    slackChannel: 'postgres',
+    slackChannel: '#postgres',
     runE2e: true],
 
   [ name: 'redis',
     components: [[name: 'redis']],
-    slackChannel: 'logger',
+    slackChannel: '#logger',
     runE2e: true],
 
   [ name: 'registry',
     components: [[name: 'registry']],
-    slackChannel: 'registry',
+    slackChannel: '#registry',
     runE2e: true],
 
   [ name: 'registry-proxy',
     components: [[name: 'registry-proxy']],
-    slackChannel: 'registry',
+    slackChannel: '#registry',
     runE2e: true],
 
   [ name: 'registry-token-refresher',
     components: [[name: 'registry-token-refresher']],
-    slackChannel: 'registry',
+    slackChannel: '#registry',
     runE2e: false],
 
   [ name: 'router',
     components: [[name: 'router']],
-    slackChannel: 'router',
+    slackChannel: '#router',
     runE2e: true],
 
   [ name: 'slugbuilder',
     components: [[name: 'slugbuilder']],
-    slackChannel: 'builder',
+    slackChannel: '#builder',
     runE2e: true],
 
   [ name: 'slugrunner',
     components: [[name: 'slugrunner']],
-    slackChannel: 'builder',
+    slackChannel: '#builder',
     runE2e: true],
 
   [ name: 'workflow-cli',
@@ -87,12 +87,12 @@ repos = [
 
   [ name: 'workflow-e2e',
     components: [[name: 'workflow-e2e']],
-    slackChannel: 'testing',
+    slackChannel: '#testing',
     runE2e: true],
 
   [ name: 'workflow-manager',
     components: [[name: 'workflow-manager']],
-    slackChannel: 'wfm',
+    slackChannel: '#wfm',
     runE2e: false],
 ]
 


### PR DESCRIPTION
This refactors the component build and `workflow-test(-pr)` jobs to notify slack via its incoming webhook api, forgoing the use of the Slack Notifications plugin.  The big win here is the ability to send a message to a channel other than the global default channel (which the aforementioned plugin does not currently allow in a secure manner).

Therefore, the component build jobs can send job statuses to their appropriate channels and the downstream test jobs can report back to the same upstream component channels...

~~For this POC to be extended to jobs such as the `workflow-test(-pr)` jobs, we would
need to move the existing `repo.slackChannel` values from groovy and into the shell
script itself, so that it can be passed repo name values at runtime and dynamically
maps these to appropriate slack channel values.~~

TODO
- [x] remove `slack-notification-test-job`
- [ ] if proposal greenlit, follow-up PR to convert all jobs to using this approach

Ref https://github.com/deis/jenkins-jobs/issues/210
Closes https://github.com/deis/jenkins-jobs/issues/210
