### PR TITLE
feat(workflow_cli_release.groovy): cgo-enabled darwin binary support

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,34 @@ Publish───────────────────────┐
 └─────────────────────────────┘
 ```
 
+### When Workflow-CLI is tagged
+```
+Trigger─────────────────────────────────┐
+│                                       │   - triggered by `v1.2.3` git tag push webhook
+│       "workflow-cli-release"          │   - pass this to downstream job(s)
+│                                       │
+└──────────┬────────────────────────────┘
+           │
+           ▼
+Build and Release - defaults────────────┐
+│                                       │   - check out TAG of source code
+│      "workflow-cli-build-tag"         │   - build cross-compiled default (linux, darwin and windows; amd64, 386) binaries
+│       TAG=v1.2.4                      │   - upload binaries
+│                                       │
+└──────────┬────────────────────────────┘
+           │
+           ▼
+Build and Release - darwin amd64────────┐
+│                                       │   - check out TAG of source code
+│ "workflow-cli-build-tag-darwin-amd64" |   - build darwin amd64 binary with CGO_ENABLED=1 on OSX slave
+│  TAG=v1.2.4                           │   - upload darwin amd64 binary
+│                                       │
+└───────────────────────────────────────┘
+
+Note: There are also "workflow-cli-build-stable(-darwin-amd64)" variants of the two downstream jobs above, but these
+are currently only triggered manually.
+```
+
 ## License
 
 Copyright 2013, 2014, 2015, 2016 Engine Yard, Inc.

--- a/bash/scripts/build_darwin_cli_binary.sh
+++ b/bash/scripts/build_darwin_cli_binary.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+# build-darwin-cli-binary builds the darwin-amd64 workflow-cli binary and is
+# intended to be run on a Mac OSX slave
+build-darwin-cli-binary() {
+  make_target="${1}"
+
+  # set up go/docker env
+  export GOPATH="${WORKSPACE}/golang"
+  export PATH=$PATH:$GOPATH/bin
+  eval "$(docker-machine env default)"
+
+  # clean workspace and bootstrap
+  rm -rf vendor/ _dist/
+  glide install
+
+  GIT_TAG="$(git describe --abbrev=0 --tags)"
+  DIST_DIR="_dist"
+  GO_LDFLAGS="-X github.com/deis/workflow-cli/version.Version=${GIT_TAG}"
+  case "${make_target}" in
+    "build-tag")
+    go build -a -ldflags "${GO_LDFLAGS}" -o "${DIST_DIR}/${GIT_TAG}/deis-${GIT_TAG}-darwin-amd64" .
+    ;;
+    "build-stable")
+    go build -a -ldflags "${GO_LDFLAGS}" -o "${DIST_DIR}/deis-stable-darwin-amd64" .
+    ;;
+  esac
+}


### PR DESCRIPTION
Sets up the workflow-cli release pipeline to promote official release `darwin-amd64` binaries that have been built on an actual OSX slave using `CGO_ENABLED=1`.

~~Requires https://github.com/deis/workflow-cli/pull/252~~

Fixes https://github.com/deis/workflow-cli/issues/246

TODO
- [x] remove test bucket override
