### PR TITLE
fix(update_commit_status): don't attempt curl if commit empty

### DIFF
--- a/bash/scripts/update_commit_status.sh
+++ b/bash/scripts/update_commit_status.sh
@@ -8,6 +8,11 @@ update-commit-status() {
   target_url="${4}"
   description="${5}"
 
+  if [ -z "${git_commit}" ]; then
+    echo "Commit value is empty; cannot update status."
+    return 0
+  fi
+
   data='
     {"state":"'"${commit_status}"'",
     "target_url":"'"${target_url}"'",

--- a/bash/tests/update_commit_status_test.bats
+++ b/bash/tests/update_commit_status_test.bats
@@ -39,7 +39,16 @@ strip-ws() {
     Updating commit '\'${git_commit}\'' in repo '\'${repo_name}\'' with the following data:
     '${expected_data}'
   '
-  
+
+  [ "${status}" -eq 0 ]
+  [ "$(strip-ws "${output}")" == "$(strip-ws "${expected_output}")" ]
+}
+
+@test "update-commit-status: commit empty" {
+  run update-commit-status
+
+  expected_output='Commit value is empty; cannot update status.'
+
   [ "${status}" -eq 0 ]
   [ "$(strip-ws "${output}")" == "$(strip-ws "${expected_output}")" ]
 }


### PR DESCRIPTION
See https://ci.deis.io/job/workflow-test-pr/7601/console for unnecessary noise/action when there is no git commit to update (job triggered by timer)
