### PR TITLE
ref(*): create reusable slackNotify dsl

### DIFF
--- a/bash/scripts/slack_notify.sh
+++ b/bash/scripts/slack_notify.sh
@@ -58,3 +58,22 @@ get-status-color() {
 
   echo "${color}"
 }
+
+format-test-job-message() {
+  issueWarning="${1}"
+
+  message=''
+  if [ -n "${UPSTREAM_BUILD_URL}" ]; then
+    message="Upstream Build: ${UPSTREAM_BUILD_URL}"
+  fi
+  if [ -n "${COMMIT_AUTHOR_EMAIL}" ]; then
+    message="${message}
+    Commit Author: ${COMMIT_AUTHOR_EMAIL}"
+  fi
+  if [ -n "${COMPONENT_REPO}" ] && $issueWarning; then
+    message="${message}
+    *Note: This implies component '${COMPONENT_REPO}' has not been promoted as a release candidate!*"
+  fi
+
+  echo "${message}"
+}

--- a/bash/scripts/update_commit_status.sh
+++ b/bash/scripts/update_commit_status.sh
@@ -8,11 +8,6 @@ update-commit-status() {
   target_url="${4}"
   description="${5}"
 
-  if [ -z "${git_commit}" ]; then
-    echo "Commit value is empty; cannot update status."
-    return 0
-  fi
-
   data='
     {"state":"'"${commit_status}"'",
     "target_url":"'"${target_url}"'",

--- a/bash/tests/slack_notify_test.bats
+++ b/bash/tests/slack_notify_test.bats
@@ -93,3 +93,78 @@ strip-ws() {
   [ "${status}" -eq 1 ]
   [ "${output}" == "Usage: slack-notify channel status [message]" ]
 }
+
+@test "format-test-job-message: UPSTREAM_BUILD_URL exists" {
+  UPSTREAM_BUILD_URL="bogus.upstream.build.url"
+
+  expected_output='
+    Upstream Build: '"${UPSTREAM_BUILD_URL}"'
+  '
+
+  run format-test-job-message false
+
+  [ "${status}" -eq 0 ]
+  [ "$(strip-ws "${output}")" == "$(strip-ws "${expected_output}")" ]
+}
+
+@test "format-test-job-message: COMMIT_AUTHOR_EMAIL exists" {
+  COMMIT_AUTHOR_EMAIL="commit@author.me"
+
+  expected_output='
+    Commit Author: '"${COMMIT_AUTHOR_EMAIL}"'
+  '
+
+  run format-test-job-message false
+
+  [ "${status}" -eq 0 ]
+  [ "$(strip-ws "${output}")" == "$(strip-ws "${expected_output}")" ]
+}
+
+@test "format-test-job-message: COMPONENT_REPO, UPSTREAM_BUILD_URL and COMMIT_AUTHOR_EMAIL exist, issue warning true" {
+  COMPONENT_REPO="test-component"
+  UPSTREAM_BUILD_URL="bogus.upstream.build.url"
+  COMMIT_AUTHOR_EMAIL="commit@author.me"
+
+  expected_output='
+    Upstream Build: '"${UPSTREAM_BUILD_URL}"'
+    Commit Author: '"${COMMIT_AUTHOR_EMAIL}"'
+    *Note: This implies component '"'${COMPONENT_REPO}'"' has not been promoted as a release candidate!*
+  '
+
+  run format-test-job-message true
+  
+  [ "${status}" -eq 0 ]
+  [ "$(strip-ws "${output}")" == "$(strip-ws "${expected_output}")" ]
+}
+
+@test "format-test-job-message: COMPONENT_REPO, UPSTREAM_BUILD_URL and COMMIT_AUTHOR_EMAIL exist, issue warning false" {
+  COMPONENT_REPO="test-component"
+  UPSTREAM_BUILD_URL="bogus.upstream.build.url"
+  COMMIT_AUTHOR_EMAIL="commit@author.me"
+
+  expected_output='
+    Upstream Build: '"${UPSTREAM_BUILD_URL}"'
+    Commit Author: '"${COMMIT_AUTHOR_EMAIL}"'
+  '
+
+  run format-test-job-message false
+
+  [ "${status}" -eq 0 ]
+  [ "$(strip-ws "${output}")" == "$(strip-ws "${expected_output}")" ]
+}
+
+@test "format-test-job-message: UPSTREAM_BUILD_URL and COMMIT_AUTHOR_EMAIL exist, issue warning true" {
+  # No COMPONENT_REPO in env, so warning will not be issued
+  UPSTREAM_BUILD_URL="bogus.upstream.build.url"
+  COMMIT_AUTHOR_EMAIL="commit@author.me"
+
+  expected_output='
+    Upstream Build: '"${UPSTREAM_BUILD_URL}"'
+    Commit Author: '"${COMMIT_AUTHOR_EMAIL}"'
+  '
+
+  run format-test-job-message true
+
+  [ "${status}" -eq 0 ]
+  [ "$(strip-ws "${output}")" == "$(strip-ws "${expected_output}")" ]
+}

--- a/bash/tests/update_commit_status_test.bats
+++ b/bash/tests/update_commit_status_test.bats
@@ -43,12 +43,3 @@ strip-ws() {
   [ "${status}" -eq 0 ]
   [ "$(strip-ws "${output}")" == "$(strip-ws "${expected_output}")" ]
 }
-
-@test "update-commit-status: commit empty" {
-  run update-commit-status
-
-  expected_output='Commit value is empty; cannot update status.'
-
-  [ "${status}" -eq 0 ]
-  [ "$(strip-ws "${output}")" == "$(strip-ws "${expected_output}")" ]
-}

--- a/common/dsl.groovy
+++ b/common/dsl.groovy
@@ -1,0 +1,25 @@
+def workspace = new File(".").getAbsolutePath()
+if (!new File("${workspace}/common/dsl.groovy").canRead()) { workspace = "${WORKSPACE}"}
+
+// Common/Re-usable DSL functions
+
+slackNotify = { Map notification ->
+  return {
+    postBuildScripts {
+      onlyIfBuildSucceeds(false)
+      steps {
+        notification.statuses.each { String buildStatus ->
+          conditionalSteps {
+            condition {
+              status(buildStatus, buildStatus)
+              steps {
+                shell new File("${workspace}/bash/scripts/slack_notify.sh").text +
+                  "slack-notify ${notification.channel} ${buildStatus} ${notification.message}"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/common/repo.groovy
+++ b/common/repo.groovy
@@ -83,6 +83,7 @@ repos = [
     runE2e: true],
 
   [ name: 'workflow-cli',
+    slackChannel: '#workflow',
     buildJobs: false],
 
   [ name: 'workflow-e2e',

--- a/common/var.groovy
+++ b/common/var.groovy
@@ -1,6 +1,7 @@
 def workspace = new File(".").getAbsolutePath()
-if (!new File("${workspace}/common.groovy").canRead()) { workspace = "${WORKSPACE}"}
-evaluate(new File("${workspace}/repo.groovy"))
+if (!new File("${workspace}/common/var.groovy").canRead()) { workspace = "${WORKSPACE}"}
+evaluate(new File("${workspace}/common/repo.groovy"))
+evaluate(new File("${workspace}/common/dsl.groovy"))
 
 def workflowChartRelease = 'v2.6.0'
 def testJobRootName = 'workflow-test'

--- a/jobs/apptypes_test.groovy
+++ b/jobs/apptypes_test.groovy
@@ -1,6 +1,6 @@
 def workspace = new File(".").getAbsolutePath()
-if (!new File("${workspace}/common.groovy").canRead()) { workspace = "${WORKSPACE}"}
-evaluate(new File("${workspace}/common.groovy"))
+if (!new File("${workspace}/common/var.groovy").canRead()) { workspace = "${WORKSPACE}"}
+evaluate(new File("${workspace}/common/var.groovy"))
 
 name = "apptypes_e2e"
 

--- a/jobs/clusterator_jobs.groovy
+++ b/jobs/clusterator_jobs.groovy
@@ -1,6 +1,6 @@
 def workspace = new File(".").getAbsolutePath()
-if (!new File("${workspace}/common.groovy").canRead()) { workspace = "${WORKSPACE}"}
-evaluate(new File("${workspace}/common.groovy"))
+if (!new File("${workspace}/common/var.groovy").canRead()) { workspace = "${WORKSPACE}"}
+evaluate(new File("${workspace}/common/var.groovy"))
 
 job("clusterator-create") {
   description "Create a set number of clusters in the deis leasable project. This job runs Monday-Friday at 7AM."

--- a/jobs/component_promote.groovy
+++ b/jobs/component_promote.groovy
@@ -1,6 +1,6 @@
 def workspace = new File(".").getAbsolutePath()
-if (!new File("${workspace}/common.groovy").canRead()) { workspace = "${WORKSPACE}"}
-evaluate(new File("${workspace}/common.groovy"))
+if (!new File("${workspace}/common/var.groovy").canRead()) { workspace = "${WORKSPACE}"}
+evaluate(new File("${workspace}/common/var.groovy"))
 
 job('component-promote') {
   description """
@@ -14,15 +14,12 @@ job('component-promote') {
     maxTotal(defaults.maxTotalConcurrentBuilds)
   }
 
-  logRotator {
-    daysToKeep defaults.daysToKeep
+  publishers {
+    slackNotify(channel: '${UPSTREAM_SLACK_CHANNEL}', statuses: ['FAILURE'])
   }
 
-  publishers {
-    slackNotifications {
-      notifyFailure()
-      notifyRepeatedFailure()
-    }
+  logRotator {
+    daysToKeep defaults.daysToKeep
   }
 
   parameters {
@@ -32,6 +29,7 @@ job('component-promote') {
     stringParam('QUAY_EMAIL', 'deis+jenkins@deis.com', 'Quay email address')
     stringParam('COMPONENT_NAME', '', 'Component name')
     stringParam('COMPONENT_SHA', '', 'Commit sha used for image tag')
+    stringParam('UPSTREAM_SLACK_CHANNEL', defaults.slack.channel, 'Upstream/Component slack channel')
   }
 
   wrappers {
@@ -41,6 +39,7 @@ job('component-promote') {
     credentialsBinding {
       string("DOCKER_PASSWORD", "0d1f268f-407d-4cd9-a3c2-0f9671df0104")
       string("QUAY_PASSWORD", "8317a529-10f7-40b5-abd4-a42f242f22f0")
+      string("SLACK_INCOMING_WEBHOOK_URL", defaults.slack.webhookURL)
     }
   }
 

--- a/jobs/deis_com.groovy
+++ b/jobs/deis_com.groovy
@@ -1,6 +1,6 @@
 def workspace = new File(".").getAbsolutePath()
-if (!new File("${workspace}/common.groovy").canRead()) { workspace = "${WORKSPACE}"}
-evaluate(new File("${workspace}/common.groovy"))
+if (!new File("${workspace}/common/var.groovy").canRead()) { workspace = "${WORKSPACE}"}
+evaluate(new File("${workspace}/common/var.groovy"))
 
 repo_name = 'deis.com'
 downstreamJobName = 'deploy_website'

--- a/jobs/deploy_website.groovy
+++ b/jobs/deploy_website.groovy
@@ -1,6 +1,6 @@
 def workspace = new File(".").getAbsolutePath()
-if (!new File("${workspace}/common.groovy").canRead()) { workspace = "${WORKSPACE}"}
-evaluate(new File("${workspace}/common.groovy"))
+if (!new File("${workspace}/common/var.groovy").canRead()) { workspace = "${WORKSPACE}"}
+evaluate(new File("${workspace}/common/var.groovy"))
 
 name = 'deploy_website'
 

--- a/jobs/e2e_runner.groovy
+++ b/jobs/e2e_runner.groovy
@@ -1,6 +1,6 @@
 def workspace = new File(".").getAbsolutePath()
-if (!new File("${workspace}/common.groovy").canRead()) { workspace = "${WORKSPACE}"}
-evaluate(new File("${workspace}/common.groovy"))
+if (!new File("${workspace}/common/var.groovy").canRead()) { workspace = "${WORKSPACE}"}
+evaluate(new File("${workspace}/common/var.groovy"))
 
 [ [type: 'master'],
   [type: 'pr'],

--- a/jobs/jenkins_jobs_pr.groovy
+++ b/jobs/jenkins_jobs_pr.groovy
@@ -1,6 +1,6 @@
 def workspace = new File(".").getAbsolutePath()
-if (!new File("${workspace}/common.groovy").canRead()) { workspace = "${WORKSPACE}"}
-evaluate(new File("${workspace}/common.groovy"))
+if (!new File("${workspace}/common/var.groovy").canRead()) { workspace = "${WORKSPACE}"}
+evaluate(new File("${workspace}/common/var.groovy"))
 
 name = 'jenkins-jobs-pr'
 

--- a/jobs/release_candidate_promote.groovy
+++ b/jobs/release_candidate_promote.groovy
@@ -1,6 +1,6 @@
 def workspace = new File(".").getAbsolutePath()
-if (!new File("${workspace}/common.groovy").canRead()) { workspace = "${WORKSPACE}"}
-evaluate(new File("${workspace}/common.groovy"))
+if (!new File("${workspace}/common/var.groovy").canRead()) { workspace = "${WORKSPACE}"}
+evaluate(new File("${workspace}/common/var.groovy"))
 
 job('release-candidate-promote') {
   description """
@@ -15,10 +15,7 @@ job('release-candidate-promote') {
   }
 
   publishers {
-    slackNotifications {
-      notifyFailure()
-      notifyRepeatedFailure()
-    }
+    slackNotify(channel: '${UPSTREAM_SLACK_CHANNEL}', statuses: ['FAILURE'])
   }
 
   parameters {
@@ -29,6 +26,7 @@ job('release-candidate-promote') {
     stringParam('COMPONENT_NAME', '', 'Component name')
     stringParam('COMPONENT_SHA', '', 'Commit sha used for candidate image tag')
     stringParam('RELEASE_TAG', '', 'Release tag value for retagging candidate image')
+    stringParam('UPSTREAM_SLACK_CHANNEL', defaults.slack.channel, 'Upstream/Component Slack channel')
   }
 
   wrappers {
@@ -38,6 +36,7 @@ job('release-candidate-promote') {
     credentialsBinding {
       string("DOCKER_PASSWORD", "0d1f268f-407d-4cd9-a3c2-0f9671df0104")
       string("QUAY_PASSWORD", "8317a529-10f7-40b5-abd4-a42f242f22f0")
+      string("SLACK_INCOMING_WEBHOOK_URL", defaults.slack.webhookURL)
     }
   }
 

--- a/jobs/seed_repos.groovy
+++ b/jobs/seed_repos.groovy
@@ -1,6 +1,6 @@
 def workspace = new File(".").getAbsolutePath()
-if (!new File("${workspace}/common.groovy").canRead()) { workspace = "${WORKSPACE}"}
-evaluate(new File("${workspace}/common.groovy"))
+if (!new File("${workspace}/common/var.groovy").canRead()) { workspace = "${WORKSPACE}"}
+evaluate(new File("${workspace}/common/var.groovy"))
 
 name = 'deis-seed-repos'
 repoName = 'seed-repo'

--- a/jobs/storage_test.groovy
+++ b/jobs/storage_test.groovy
@@ -1,6 +1,6 @@
 def workspace = new File(".").getAbsolutePath()
-if (!new File("${workspace}/common.groovy").canRead()) { workspace = "${WORKSPACE}"}
-evaluate(new File("${workspace}/common.groovy"))
+if (!new File("${workspace}/common/var.groovy").canRead()) { workspace = "${WORKSPACE}"}
+evaluate(new File("${workspace}/common/var.groovy"))
 
 name = "storagetype_e2e"
 

--- a/jobs/workflow_cli_release.groovy
+++ b/jobs/workflow_cli_release.groovy
@@ -1,6 +1,6 @@
 def workspace = new File(".").getAbsolutePath()
-if (!new File("${workspace}/common.groovy").canRead()) { workspace = "${WORKSPACE}"}
-evaluate(new File("${workspace}/common.groovy"))
+if (!new File("${workspace}/common/var.groovy").canRead()) { workspace = "${WORKSPACE}"}
+evaluate(new File("${workspace}/common/var.groovy"))
 
 def repoName = 'workflow-cli'
 
@@ -40,10 +40,7 @@ job("${repoName}-release") {
   }
 
   publishers {
-    slackNotifications {
-      notifyFailure()
-      notifyRepeatedFailure()
-    }
+    slackNotify(channel: repos[repoName].slackChannel, statuses: ['FAILURE'])
   }
 
   logRotator {
@@ -62,6 +59,9 @@ job("${repoName}-release") {
     buildName('${GIT_BRANCH} ${TAG} #${BUILD_NUMBER}')
     timestamps()
     colorizeOutput 'xterm'
+    credentialsBinding {
+      string("SLACK_INCOMING_WEBHOOK_URL", defaults.slack.webhookURL)
+    }
   }
 
   steps {
@@ -112,10 +112,7 @@ downstreamJobs.each{ Map thisJob ->
     }
 
     publishers {
-      slackNotifications {
-        notifyFailure()
-        notifyRepeatedFailure()
-      }
+      slackNotify([channel: repos[repoName].slackChannel, statuses: ['FAILURE']])
     }
 
     logRotator {
@@ -186,10 +183,7 @@ downstreamJobs.each{ Map thisJob ->
     }
 
     publishers {
-      slackNotifications {
-        notifyFailure()
-        notifyRepeatedFailure()
-      }
+      slackNotify([channel: repos[repoName].slackChannel, statuses: ['FAILURE']])
     }
 
     logRotator {

--- a/jobs/workflow_docs.groovy
+++ b/jobs/workflow_docs.groovy
@@ -1,6 +1,6 @@
 def workspace = new File(".").getAbsolutePath()
-if (!new File("${workspace}/common.groovy").canRead()) { workspace = "${WORKSPACE}"}
-evaluate(new File("${workspace}/common.groovy"))
+if (!new File("${workspace}/common/var.groovy").canRead()) { workspace = "${WORKSPACE}"}
+evaluate(new File("${workspace}/common/var.groovy"))
 
 name = 'workflow-docs'
 downstreamJobName = 'deploy_website'

--- a/jobs/workflow_test.groovy
+++ b/jobs/workflow_test.groovy
@@ -1,6 +1,6 @@
 def workspace = new File(".").getAbsolutePath()
-if (!new File("${workspace}/common.groovy").canRead()) { workspace = "${WORKSPACE}"}
-evaluate(new File("${workspace}/common.groovy"))
+if (!new File("${workspace}/common/var.groovy").canRead()) { workspace = "${WORKSPACE}"}
+evaluate(new File("${workspace}/common/var.groovy"))
 
 [
   [type: 'master'],
@@ -45,33 +45,26 @@ evaluate(new File("${workspace}/common.groovy"))
               condition {
                 status(buildStatus, buildStatus)
                 steps {
-                  // Dispatch Slack notification
-                  def channel = '${UPSTREAM_SLACK_CHANNEL}'
+                  // Send Slack Notification
+                  def issueWarning = (isMaster && buildStatus == 'FAILURE')
                   shell new File("${workspace}/bash/scripts/slack_notify.sh").text +
                     """
-                      # format message depending on values present in env
-                      message=''
-                      if [ -n "\${UPSTREAM_BUILD_URL}" ]; then
-                        message="Upstream Build: \${UPSTREAM_BUILD_URL}"
-                      fi
-                      if [ -n "\${COMMIT_AUTHOR_EMAIL}" ]; then
-                        message="\${message}
-                        Commit Author: \${COMMIT_AUTHOR_EMAIL}"
-                      fi
-
-                      slack-notify ${channel} ${buildStatus} "\${message}"
+                      message="\$(format-test-job-message ${issueWarning})"
+                      slack-notify \${UPSTREAM_SLACK_CHANNEL} ${buildStatus} "\${message}"
                     """.stripIndent().trim()
 
-                  // Update GitHub PR
+                  // Update GitHub PR status, if applicable
                   if (isPR) {
                     shell new File("${workspace}/bash/scripts/update_commit_status.sh").text +
                       """
-                        update-commit-status \
-                          ${commitStatus} \
-                          \${COMPONENT_REPO} \
-                          \${ACTUAL_COMMIT} \
-                          \${BUILD_URL} \
-                          "${name} job ${buildStatus}"
+                        if [ -n "\${ACTUAL_COMMIT}" ]; then
+                          update-commit-status \
+                            ${commitStatus} \
+                            \${COMPONENT_REPO} \
+                            \${ACTUAL_COMMIT} \
+                            \${BUILD_URL} \
+                            "${name} job ${buildStatus}"
+                        fi
                       """.stripIndent().trim()
                   }
                 }
@@ -99,7 +92,7 @@ evaluate(new File("${workspace}/common.groovy"))
         stringParam(repo.commitEnvVar, '', "${repo.name} commit SHA")
       }
       stringParam('UPSTREAM_BUILD_URL', '', "Upstream build url")
-      stringParam('UPSTREAM_SLACK_CHANNEL', '#testing', "Upstream Slack channel")
+      stringParam('UPSTREAM_SLACK_CHANNEL', defaults.slack.channel, "Upstream Slack channel")
       stringParam('COMPONENT_REPO', '', "Component repo name")
       stringParam('ACTUAL_COMMIT', '', "Component commit SHA")
       stringParam('GINKGO_NODES', '15', "Number of parallel executors to use when running e2e tests")
@@ -138,12 +131,14 @@ evaluate(new File("${workspace}/common.groovy"))
       if (isPR) { // update commit with pending status while tests run
         shell new File("${workspace}/bash/scripts/update_commit_status.sh").text +
           """
-            update-commit-status \
-              "pending" \
-              \${COMPONENT_REPO} \
-              \${ACTUAL_COMMIT} \
-              \${BUILD_URL} \
-              "Running e2e tests..."
+            if [ -n "\${ACTUAL_COMMIT}" ]; then
+              update-commit-status \
+                "pending" \
+                \${COMPONENT_REPO} \
+                \${ACTUAL_COMMIT} \
+                \${BUILD_URL} \
+                "Running e2e tests..."
+            fi
           """.stripIndent().trim()
 
         shell new File("${workspace}/bash/scripts/setup_helmc_environment.sh").text +
@@ -155,7 +150,7 @@ evaluate(new File("${workspace}/common.groovy"))
 
       shell e2eRunnerJob
 
-      if (isMaster) { // send component name and sha to downstream component-promote job
+      if (isMaster) { // send component info to downstream component-promote job
         shell new File("${workspace}/bash/scripts/get_component_and_sha.sh").text +
           """
             #!/usr/bin/env bash
@@ -163,7 +158,8 @@ evaluate(new File("${workspace}/common.groovy"))
             set -eo pipefail
 
             mkdir -p ${defaults.tmpPath}
-            get-component-and-sha >> ${defaults.envFile}
+            { get-component-and-sha; \
+              echo "UPSTREAM_SLACK_CHANNEL=\${UPSTREAM_SLACK_CHANNEL}"; } >> ${defaults.envFile}
           """.stripIndent().trim()
 
         conditionalSteps {

--- a/jobs/workflow_test_release.groovy
+++ b/jobs/workflow_test_release.groovy
@@ -1,6 +1,6 @@
 def workspace = new File(".").getAbsolutePath()
-if (!new File("${workspace}/common.groovy").canRead()) { workspace = "${WORKSPACE}"}
-evaluate(new File("${workspace}/common.groovy"))
+if (!new File("${workspace}/common/var.groovy").canRead()) { workspace = "${WORKSPACE}"}
+evaluate(new File("${workspace}/common/var.groovy"))
 
 name = 'workflow-test-release'
 
@@ -24,23 +24,20 @@ job(name) {
   }
 
   publishers {
-    slackNotifications {
-      notifyFailure()
-      includeTestSummary()
-     }
+    slackNotify(channel: '#release', statuses: ['FAILURE'])
 
-     archiveJunit('${BUILD_NUMBER}/logs/junit*.xml') {
-       retainLongStdout(false)
-       allowEmptyResults(true)
-     }
+    archiveJunit('${BUILD_NUMBER}/logs/junit*.xml') {
+     retainLongStdout(false)
+     allowEmptyResults(true)
+    }
 
-     archiveArtifacts {
-       pattern('${BUILD_NUMBER}/logs/**')
-       onlyIfSuccessful(false)
-       fingerprint(false)
-       allowEmpty(true)
-     }
-   }
+    archiveArtifacts {
+     pattern('${BUILD_NUMBER}/logs/**')
+     onlyIfSuccessful(false)
+     fingerprint(false)
+     allowEmpty(true)
+    }
+  }
 
    concurrentBuild()
    throttleConcurrentBuilds {
@@ -76,6 +73,7 @@ job(name) {
     credentialsBinding {
       string("AUTH_TOKEN", "a62d7fe9-5b74-47e3-9aa5-2458ba32da52")
       string("GITHUB_ACCESS_TOKEN", defaults.github.credentialsID)
+      string("SLACK_INCOMING_WEBHOOK_URL", defaults.slack.webhookURL)
     }
   }
 


### PR DESCRIPTION
Follow-up refactor PR stemming from https://github.com/deis/jenkins-jobs/pull/243

Changes include:
- place all common vars/defaults/dsl into a new `common` dir, rather than filling up the same/former `common.groovy` file.  We now have `common/var.groovy`, `common/repo.groovy` and `common/dsl.groovy`.
- creation of aforementioned reusable `slackNotify` dsl function (in `common/dsl.groovy`)
- convert other relevant jobs over to using `slackNotify` that had previously been using the Slack Notifications Plugin (some already transitioned in https://github.com/deis/jenkins-jobs/pull/243)
- ~~refactor unique slack message logic for `workflow-test(-pr)` jobs  into its own function (`format-test-job-message` in `bash/scripts/slack_notify.sh`) and cover under test.~~

TODO
- [ ] demo these changes by re-building jobs off of this branch for a spell
