### PR TITLE
ref(slack_notify.sh): add format-test-job-message function

### DIFF
--- a/bash/scripts/slack_notify.sh
+++ b/bash/scripts/slack_notify.sh
@@ -58,3 +58,22 @@ get-status-color() {
 
   echo "${color}"
 }
+
+format-test-job-message() {
+  issueWarning="${1}"
+
+  message=''
+  if [ -n "${UPSTREAM_BUILD_URL}" ]; then
+    message="Upstream Build: ${UPSTREAM_BUILD_URL}"
+  fi
+  if [ -n "${COMMIT_AUTHOR_EMAIL}" ]; then
+    message="${message}
+    Commit Author: ${COMMIT_AUTHOR_EMAIL}"
+  fi
+  if [ -n "${COMPONENT_REPO}" ] && $issueWarning; then
+    message="${message}
+    *Note: This implies component '${COMPONENT_REPO}' has not been promoted as a release candidate!*"
+  fi
+
+  echo "${message}"
+}

--- a/bash/tests/slack_notify_test.bats
+++ b/bash/tests/slack_notify_test.bats
@@ -93,3 +93,78 @@ strip-ws() {
   [ "${status}" -eq 1 ]
   [ "${output}" == "Usage: slack-notify channel status [message]" ]
 }
+
+@test "format-test-job-message: UPSTREAM_BUILD_URL exists" {
+  UPSTREAM_BUILD_URL="bogus.upstream.build.url"
+
+  expected_output='
+    Upstream Build: '"${UPSTREAM_BUILD_URL}"'
+  '
+
+  run format-test-job-message false
+
+  [ "${status}" -eq 0 ]
+  [ "$(strip-ws "${output}")" == "$(strip-ws "${expected_output}")" ]
+}
+
+@test "format-test-job-message: COMMIT_AUTHOR_EMAIL exists" {
+  COMMIT_AUTHOR_EMAIL="commit@author.me"
+
+  expected_output='
+    Commit Author: '"${COMMIT_AUTHOR_EMAIL}"'
+  '
+
+  run format-test-job-message false
+
+  [ "${status}" -eq 0 ]
+  [ "$(strip-ws "${output}")" == "$(strip-ws "${expected_output}")" ]
+}
+
+@test "format-test-job-message: COMPONENT_REPO, UPSTREAM_BUILD_URL and COMMIT_AUTHOR_EMAIL exist, issue warning true" {
+  COMPONENT_REPO="test-component"
+  UPSTREAM_BUILD_URL="bogus.upstream.build.url"
+  COMMIT_AUTHOR_EMAIL="commit@author.me"
+
+  expected_output='
+    Upstream Build: '"${UPSTREAM_BUILD_URL}"'
+    Commit Author: '"${COMMIT_AUTHOR_EMAIL}"'
+    *Note: This implies component '"'${COMPONENT_REPO}'"' has not been promoted as a release candidate!*
+  '
+
+  run format-test-job-message true
+
+  [ "${status}" -eq 0 ]
+  [ "$(strip-ws "${output}")" == "$(strip-ws "${expected_output}")" ]
+}
+
+@test "format-test-job-message: COMPONENT_REPO, UPSTREAM_BUILD_URL and COMMIT_AUTHOR_EMAIL exist, issue warning false" {
+  COMPONENT_REPO="test-component"
+  UPSTREAM_BUILD_URL="bogus.upstream.build.url"
+  COMMIT_AUTHOR_EMAIL="commit@author.me"
+
+  expected_output='
+    Upstream Build: '"${UPSTREAM_BUILD_URL}"'
+    Commit Author: '"${COMMIT_AUTHOR_EMAIL}"'
+  '
+
+  run format-test-job-message false
+
+  [ "${status}" -eq 0 ]
+  [ "$(strip-ws "${output}")" == "$(strip-ws "${expected_output}")" ]
+}
+
+@test "format-test-job-message: UPSTREAM_BUILD_URL and COMMIT_AUTHOR_EMAIL exist, issue warning true" {
+  # No COMPONENT_REPO in env, so warning will not be issued
+  UPSTREAM_BUILD_URL="bogus.upstream.build.url"
+  COMMIT_AUTHOR_EMAIL="commit@author.me"
+
+  expected_output='
+    Upstream Build: '"${UPSTREAM_BUILD_URL}"'
+    Commit Author: '"${COMMIT_AUTHOR_EMAIL}"'
+  '
+
+  run format-test-job-message true
+
+  [ "${status}" -eq 0 ]
+  [ "$(strip-ws "${output}")" == "$(strip-ws "${expected_output}")" ]
+}

--- a/jobs/workflow_test.groovy
+++ b/jobs/workflow_test.groovy
@@ -46,20 +46,11 @@ evaluate(new File("${workspace}/common.groovy"))
                 status(buildStatus, buildStatus)
                 steps {
                   // Dispatch Slack notification
-                  def channel = '${UPSTREAM_SLACK_CHANNEL}'
+                  def issueWarning = (isMaster && buildStatus == 'FAILURE')
                   shell new File("${workspace}/bash/scripts/slack_notify.sh").text +
                     """
-                      # format message depending on values present in env
-                      message=''
-                      if [ -n "\${UPSTREAM_BUILD_URL}" ]; then
-                        message="Upstream Build: \${UPSTREAM_BUILD_URL}"
-                      fi
-                      if [ -n "\${COMMIT_AUTHOR_EMAIL}" ]; then
-                        message="\${message}
-                        Commit Author: \${COMMIT_AUTHOR_EMAIL}"
-                      fi
-
-                      slack-notify ${channel} ${buildStatus} "\${message}"
+                      message="\$(format-test-job-message ${issueWarning})"
+                      slack-notify \${UPSTREAM_SLACK_CHANNEL} ${buildStatus} "\${message}"
                     """.stripIndent().trim()
 
                   // Update GitHub PR


### PR DESCRIPTION
Refactor to pull some special `workflow-test(-pr)` job notification messaging logic out and under test.  

While doing so, added a warning, if applicable, relating to failure to promote release candidates on master pipeline failures.
