### PR TITLE
ref(common.groovy): single quotes for downloadAndInit script

### DIFF
--- a/common.groovy
+++ b/common.groovy
@@ -37,14 +37,14 @@ defaults = [
     remoteBranch: 'master',
     remoteName: 'deis',
     version: 'v2.0.0-beta.1',
-    downloadAndInit: """
-      export HELM_VERSION="\${HELM_VERSION:-canary}"
-      export HELM_OS=linux HELM_HOME="/home/jenkins/workspace/\${JOB_NAME}/\${BUILD_NUMBER}" \
-        && wget http://storage.googleapis.com/kubernetes-helm/helm-"\${HELM_VERSION}"-"\${HELM_OS}"-amd64.tar.gz \
-        && tar -zxvf helm-"\${HELM_VERSION}"-"\${HELM_OS}"-amd64.tar.gz \
-        && export PATH="\${HELM_OS}-amd64:\${PATH}" \
+    downloadAndInit: '''
+      export HELM_VERSION="${HELM_VERSION:-canary}"
+      export HELM_OS=linux HELM_HOME="/home/jenkins/workspace/${JOB_NAME}/${BUILD_NUMBER}" \
+        && wget http://storage.googleapis.com/kubernetes-helm/helm-"${HELM_VERSION}"-"${HELM_OS}"-amd64.tar.gz \
+        && tar -zxvf helm-"${HELM_VERSION}"-"${HELM_OS}"-amd64.tar.gz \
+        && export PATH="${HELM_OS}-amd64:${PATH}" \
         && helm init -c
-    """,
+    ''',
   ],
   github: [
     username: 'deis-admin',


### PR DESCRIPTION
As we don't need to interpolate any groovy-land vars, let's single
quote (literalize) the script so we don't have to escape bash env vars
