### PR TITLE
feat(clusterator_jobs): provision 2 dynamic clusters

### DIFF
--- a/jobs/clusterator_jobs.groovy
+++ b/jobs/clusterator_jobs.groovy
@@ -14,7 +14,7 @@ job("clusterator-create") {
   }
 
   parameters {
-    stringParam('NUMBER_OF_CLUSTERS', '10', 'Number of clusters to create at 1 time')
+    stringParam('NUMBER_OF_CLUSTERS', '2', 'Number of clusters to create at 1 time')
     stringParam('NUM_NODES', '5', 'Number of nodes in each cluster')
     stringParam('MACHINE_TYPE', 'n1-standard-4', 'Node type')
     stringParam('VERSION', '', 'The version of kubernetes to use.')


### PR DESCRIPTION
Provisioning (and destroying) 10 dynamic clusters daily looks like overkill for Workflow's current CI load. This reduces that number to 2 for now, which is just a [SWAG](https://en.wikipedia.org/wiki/Scientific_wild-ass_guess), but one that saves money and resources.