### PR TITLE
feat(jobs/deis_com.groovy): add daily cron trigger

### DIFF
--- a/jobs/deis_com.groovy
+++ b/jobs/deis_com.groovy
@@ -28,11 +28,12 @@ job("deis-com-master") {
   }
 
   triggers {
+    cron('H 7 * * *')
     githubPush()
   }
 
   publishers {
-    downstream('deis-com-deploy', 'UNSTABLE')
+    downstream(downstreamJobName, 'UNSTABLE')
   }
 
   wrappers {


### PR DESCRIPTION
Supports posting future-dated blog posts on the intended day.
(Said posts can then be commited to master and await their posting date
as given in post file name.)

cc @mboersma @slack 