### PR TITLE
feat(*): add component chart publishing to -dev repo

### DIFF
--- a/bash/scripts/get_merge_commit_changes.sh
+++ b/bash/scripts/get_merge_commit_changes.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+get-merge-commit-changes() {
+  merge_commit="${1}"
+
+  # Grab 'Merge: abc1234 def5678' and convert to abc1234..def5678
+  child_commit_range="$(git show "${merge_commit}" | grep 'Merge:' | cut -c8- | sed 's/ /../g')"
+
+  echo "Returning changes from merge commit '${merge_commit}' using the commit range: ${child_commit_range}" >&2
+
+  git diff-tree --no-commit-id --name-only -r "${child_commit_range}"
+}

--- a/bash/scripts/helm_chart_actions.sh
+++ b/bash/scripts/helm_chart_actions.sh
@@ -53,7 +53,7 @@ download-and-init-helm() {
   export HELM_OS="${HELM_OS:-linux}"
   export HELM_HOME="/home/jenkins/workspace/${JOB_NAME}/${BUILD_NUMBER}"
 
-  wget --quiet http://storage.googleapis.com/kubernetes-helm/helm-"${HELM_VERSION}"-"${HELM_OS}"-amd64.tar.gz \
+  wget --quiet https://storage.googleapis.com/kubernetes-helm/helm-"${HELM_VERSION}"-"${HELM_OS}"-amd64.tar.gz \
     && tar -zxvf helm-"${HELM_VERSION}"-"${HELM_OS}"-amd64.tar.gz \
     && export PATH="${HELM_OS}-amd64:${PATH}" \
     && helm init -c

--- a/bash/scripts/publish_helm_chart.sh
+++ b/bash/scripts/publish_helm_chart.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+export DEIS_CHARTS_BASE_URL="https://charts.deis.com"
+export DEIS_CHARTS_BUCKET_BASE_URL="s3://helm-charts"
+
+# publish-helm-chart publishes the given chart to the chart repo determined
+# by the given repo_type
+publish-helm-chart() {
+  local chart="${1}"
+  local repo_type="${2}"
+
+  # check out RELEASE_TAG tag (if empty, just stays on master commit)
+  short_sha="${SHORT_SHA:-$(git checkout -q "${RELEASE_TAG}" && git rev-parse --short HEAD)}"
+  git_tag="${GIT_TAG:-$(git describe --abbrev=0 --tags)}"
+  timestamp="${TIMESTAMP:-$(date -u +%Y%m%d%H%M%S)}"
+  chart_repo="$(echo "${chart}-${repo_type}" | sed -e 's/-production//g')"
+
+  if [ -d "${PWD}"/charts ]; then
+    cd "${PWD}"/charts
+    download-and-init-helm
+
+    chart_version="${git_tag}"
+    if [ "${chart_repo}" == "${chart}-dev" ]; then
+      # treat this as a dev chart: increment patch version (v1.2.3 -> v1.2.4) and add prerelease build info
+      incremented_patch_version="$(( ${chart_version: -1} +1))"
+      chart_version="${chart_version%?}${incremented_patch_version}-${timestamp}-sha.${short_sha}"
+    fi
+
+    update-chart "${chart}" "${chart_version}" "${chart_repo}"
+
+    helm package "${chart}"
+
+    # download index file from aws s3 bucket
+    aws s3 cp "${DEIS_CHARTS_BUCKET_BASE_URL}/${chart_repo}/index.yaml" .
+
+    # update index file
+    helm repo index . --url "${DEIS_CHARTS_BASE_URL}/${chart_repo}" --merge ./index.yaml
+
+    # push packaged chart and updated index file to aws s3 bucket
+    aws s3 cp "${chart}-${chart_version}".tgz "${DEIS_CHARTS_BUCKET_BASE_URL}/${chart_repo}"/ \
+      && aws s3 cp index.yaml "${DEIS_CHARTS_BUCKET_BASE_URL}/${chart_repo}"/index.yaml \
+      && aws s3 cp "${chart}"/values.yaml "${DEIS_CHARTS_BUCKET_BASE_URL}/${chart_repo}/values-${chart_version}".yaml
+  else
+    echo "No 'charts' directory found at project level; nothing to publish."
+  fi
+}
+
+# update-chart updates a given chart, using the provided chart, chart_version
+# and chart_repo values.  If the chart is 'workflow', a space-delimited list of
+# component charts is expected to be present in a WORKFLOW_COMPONENTS env var
+update-chart() {
+  local chart="${1}"
+  local chart_version="${2}"
+  local chart_repo="${3}"
+
+  # update the chart version
+  perl -i -0pe "s/<Will be populated by the ci before publishing the chart>/${chart_version}/g" "${chart}"/Chart.yaml
+
+  if [ "${chart}" != 'workflow' ]; then
+    ## make component chart updates
+    if [ "${chart_repo}" != "${chart}-dev" ]; then
+      # update all org values to "deis"
+      perl -i -0pe 's/"deisci"/"deis"/g' "${chart}"/values.yaml
+      # update the image pull policy to "IfNotPresent"
+      perl -i -0pe 's/"Always"/"IfNotPresent"/g' "${chart}"/values.yaml
+      # update the dockerTag value to chart_version
+      perl -i -0pe "s/canary/${chart_version}/g" "${chart}"/values.yaml
+    fi
+  else
+    ## make workflow chart updates
+    # update requirements.yaml with correct chart version and chart repo for each component
+    for component in ${COMPONENT_CHART_AND_REPOS}; do
+      IFS=':' read -r -a chart_and_repo <<< "${component}"
+      component_chart="${chart_and_repo[0]}"
+      component_repo="${chart_and_repo[1]}"
+      latest_tag="$(get-latest-component-release "${component_repo}")"
+
+      component_chart_version="${latest_tag}"
+      component_chart_repo="${component_chart}"
+      if [ "${chart_version}" != "${git_tag}" ]; then
+        # chart version has build data; is -dev variant
+        component_chart_version=">=${latest_tag}"
+        component_chart_repo="${component_chart}-dev"
+      fi
+      perl -i -0pe 's/<'"${component_chart}"'-tag>/"'"${component_chart_version}"'"/g' "${chart}"/requirements.yaml
+      perl -i -0pe 's='"${DEIS_CHARTS_BASE_URL}/${component_chart}\n"'='"${DEIS_CHARTS_BASE_URL}/${component_chart_repo}\n"'=g' "${chart}"/requirements.yaml
+      helm repo add "${component_chart_repo}" "${DEIS_CHARTS_BASE_URL}/${component_chart_repo}"
+    done
+
+    # fetch all dependent charts based on above
+    helm dependency update "${chart}"
+
+    if [ "${chart_repo}" == "${chart}-staging" ]; then
+      # 'stage' chart on production sans index.file (so chart may not be used)
+      helm package "${chart}"
+
+      aws s3 cp "${chart}-${chart_version}".tgz "${DEIS_CHARTS_BUCKET_BASE_URL}/${chart}"/ \
+        && aws s3 cp "${chart}"/values.yaml "${DEIS_CHARTS_BUCKET_BASE_URL}/${chart}/values-${chart_version}".yaml
+    fi
+
+    if [ "${chart_repo}" != "${chart}" ]; then
+      # modify workflow-manager/doctor urls in values.yaml to point to staging
+      perl -i -0pe "s/versions.deis/versions-staging.deis/g" "${chart}"/values.yaml
+      perl -i -0pe "s/doctor.deis/doctor-staging.deis/g" "${chart}"/values.yaml
+    fi
+
+    # set WORKFLOW_TAG for downstream e2e job to read from
+    echo "WORKFLOW_TAG=${chart_version}" >> "${ENV_FILE_PATH:-/dev/null}"
+  fi
+}

--- a/bash/tests/get_merge_commit_changes_test.bats
+++ b/bash/tests/get_merge_commit_changes_test.bats
@@ -1,0 +1,21 @@
+#!/usr/bin/env bats
+
+setup() {
+  . "${BATS_TEST_DIRNAME}/../scripts/get_merge_commit_changes.sh"
+  load stub
+  stub git
+}
+
+teardown() {
+  rm_stubs
+}
+
+@test "get-merge-commit-changes : default" {
+  stub git "echo 'Merge: abc1234 def5678'"
+
+  run get-merge-commit-changes 'foo1234'
+
+  [ "${status}" -eq 0 ]
+  [ "${lines[0]}" == "Returning changes from merge commit 'foo1234' using the commit range: abc1234..def5678" ]
+  [ "${lines[1]}" == "Merge: abc1234 def5678" ]
+}

--- a/bash/tests/publish_helm_chart_test.bats
+++ b/bash/tests/publish_helm_chart_test.bats
@@ -1,0 +1,139 @@
+#!/usr/bin/env bats
+
+setup() {
+  . "${BATS_TEST_DIRNAME}/../scripts/publish_helm_chart.sh"
+  load stub
+
+  stub wget
+  stub git
+  stub aws
+  stub helm
+  stub download-and-init-helm
+  stub get-latest-component-release "echo 'v3.0.3'"
+
+  PWD="${BATS_TEST_DIRNAME}/tmp"
+  WORKDIR="${PWD}/charts"
+  ENV_FILE_PATH="${WORKDIR}/env.file"
+  SHORT_SHA='abc1234'
+  GIT_TAG='v1.2.3'
+  EXPECTED_PRERELEASE_TAG='v1.2.4'
+  TIMESTAMP="$(date -u +%Y%m%d%H%M%S)"
+}
+
+teardown() {
+  rm_stubs
+}
+
+setup-chart-workspace() {
+  chart="${1}"
+
+  mkdir -p "${WORKDIR}/${chart}"
+  echo '<Will be populated by the ci before publishing the chart>' > "${WORKDIR}/${chart}/Chart.yaml"
+}
+
+@test "publish-helm-chart: no charts dir" {
+  run publish-helm-chart
+
+  [ "${status}" -eq 0 ]
+  [ "${output}" == "No 'charts' directory found at project level; nothing to publish." ]
+}
+
+@test "publish-helm-chart: component dev" {
+  chart='router'
+  repo_type='dev'
+  setup-chart-workspace "${chart}"
+
+  run publish-helm-chart "${chart}" "${repo_type}"
+
+  [ "${status}" -eq 0 ]
+  [ "$(cat "${WORKDIR}/${chart}/Chart.yaml")" == "${EXPECTED_PRERELEASE_TAG}-${TIMESTAMP}-sha.${SHORT_SHA}" ]
+}
+
+@test "publish-helm-chart: component production" {
+  chart='router'
+  repo_type='production'
+  setup-chart-workspace "${chart}"
+
+  echo '"deisci" "Always" canary' > "${WORKDIR}/${chart}/values.yaml"
+
+  run publish-helm-chart "${chart}" "${repo_type}"
+
+  [ "${status}" -eq 0 ]
+  [ "$(cat "${WORKDIR}/${chart}/Chart.yaml")" == "${GIT_TAG}" ]
+  [ "$(cat "${WORKDIR}/${chart}/values.yaml")" == "\"deis\" \"IfNotPresent\" ${GIT_TAG}" ]
+}
+
+@test "publish-helm-chart: workflow dev" {
+  chart='workflow'
+  repo_type='dev'
+  setup-chart-workspace "${chart}"
+  COMPONENT_CHART_AND_REPOS="registry:registry registry-proxy:registry-proxy database:postgres"
+
+  echo '<registry-tag> https://charts.deis.com/registry
+<registry-proxy-tag> https://charts.deis.com/registry-proxy
+<database-tag> https://charts.deis.com/database' > "${WORKDIR}/${chart}/requirements.yaml"
+
+  echo 'versions.deis.com doctor.deis.com' > "${WORKDIR}/${chart}/values.yaml"
+
+  run publish-helm-chart "${chart}" "${repo_type}"
+
+  expected_requirements_yaml='">=v3.0.3" https://charts.deis.com/registry-dev
+">=v3.0.3" https://charts.deis.com/registry-proxy-dev
+">=v3.0.3" https://charts.deis.com/database-dev'
+
+  [ "${status}" -eq 0 ]
+  [ "$(cat "${WORKDIR}/${chart}/Chart.yaml")" == "${EXPECTED_PRERELEASE_TAG}-${TIMESTAMP}-sha.${SHORT_SHA}" ]
+  [ "$(cat "${WORKDIR}/${chart}/requirements.yaml")" == "${expected_requirements_yaml}" ]
+  [ "$(cat "${WORKDIR}/${chart}/values.yaml")" == 'versions-staging.deis.com doctor-staging.deis.com' ]
+  [ "$(cat "${WORKDIR}/env.file")" == "WORKFLOW_TAG=${EXPECTED_PRERELEASE_TAG}-${TIMESTAMP}-sha.${SHORT_SHA}" ]
+}
+
+@test "publish-helm-chart: workflow staging" {
+  chart='workflow'
+  repo_type='staging'
+  setup-chart-workspace "${chart}"
+  COMPONENT_CHART_AND_REPOS="registry:registry registry-proxy:registry-proxy database:postgres"
+
+  echo '<registry-tag> https://charts.deis.com/registry
+<registry-proxy-tag> https://charts.deis.com/registry-proxy
+<database-tag> https://charts.deis.com/database' > "${WORKDIR}/${chart}/requirements.yaml"
+
+  echo 'versions.deis.com doctor.deis.com' > "${WORKDIR}/${chart}/values.yaml"
+
+  run publish-helm-chart "${chart}" "${repo_type}"
+
+  expected_requirements_yaml='"v3.0.3" https://charts.deis.com/registry
+"v3.0.3" https://charts.deis.com/registry-proxy
+"v3.0.3" https://charts.deis.com/database'
+
+  [ "${status}" -eq 0 ]
+  [ "$(cat "${WORKDIR}/${chart}/Chart.yaml")" == "${GIT_TAG}" ]
+  [ "$(cat "${WORKDIR}/${chart}/requirements.yaml")" == "${expected_requirements_yaml}" ]
+  [ "$(cat "${WORKDIR}/${chart}/values.yaml")" == 'versions-staging.deis.com doctor-staging.deis.com' ]
+  [ "$(cat "${WORKDIR}/env.file")" == "WORKFLOW_TAG=${GIT_TAG}" ]
+}
+
+@test "publish-helm-chart: workflow production" {
+  chart='workflow'
+  repo_type='production'
+  setup-chart-workspace "${chart}"
+  COMPONENT_CHART_AND_REPOS="registry:registry registry-proxy:registry-proxy database:postgres"
+
+  echo '<registry-tag> https://charts.deis.com/registry
+<registry-proxy-tag> https://charts.deis.com/registry-proxy
+<database-tag> https://charts.deis.com/database' > "${WORKDIR}/${chart}/requirements.yaml"
+
+  echo 'versions.deis.com doctor.deis.com' > "${WORKDIR}/${chart}/values.yaml"
+
+  run publish-helm-chart "${chart}" "${repo_type}"
+
+  expected_requirements_yaml='"v3.0.3" https://charts.deis.com/registry
+"v3.0.3" https://charts.deis.com/registry-proxy
+"v3.0.3" https://charts.deis.com/database'
+
+  [ "${status}" -eq 0 ]
+  [ "$(cat "${WORKDIR}/${chart}/Chart.yaml")" == "${GIT_TAG}" ]
+  [ "$(cat "${WORKDIR}/${chart}/requirements.yaml")" == "${expected_requirements_yaml}" ]
+  [ "$(cat "${WORKDIR}/${chart}/values.yaml")" == 'versions.deis.com doctor.deis.com' ]
+  [ "$(cat "${WORKDIR}/env.file")" == "WORKFLOW_TAG=${GIT_TAG}" ]
+}

--- a/jobs/component_release.groovy
+++ b/jobs/component_release.groovy
@@ -121,6 +121,7 @@ repos.each { Map repo ->
         }
 
         if (repo.chart) {
+          // Trigger component release chart publish job to 'production' chart repo
           conditionalSteps {
             condition {
               status('SUCCESS', 'SUCCESS')
@@ -135,6 +136,7 @@ repos.each { Map repo ->
                   }
                   parameters {
                     propertiesFile(defaults.envFile)
+                    predefinedProps(['CHART_REPO_TYPE': 'production'])
                   }
                 }
               }


### PR DESCRIPTION
On master merge.  Also kicks off downstream job to update/publish
Workflow chart to corresponding workflow-dev repo...

Currently adds the bottom branch seen below:
<img width="1002" alt="k8s_helm_pipelines" src="https://cloud.githubusercontent.com/assets/9322017/20316004/6ae53cf4-ab1d-11e6-8d41-d34e0f009449.png">


Ref https://github.com/deis/jenkins-jobs/issues/286

TODO
 - [x] add check for changes in `charts/` subdir before kicking off k/helm pipeline
 - [x] cover under test
 - [x] test pipelines live by building off seed job
 - [x] remove temporary helm binary url [change](https://github.com/vdice/jenkins-jobs/blob/f25abfe3ba2ec092683354cd3933dfd04c163304/bash/scripts/helm_chart_actions.sh#L56)