### PR TITLE
ref(*): transition from helmc to helm

### DIFF
--- a/bash/scripts/run_e2e.sh
+++ b/bash/scripts/run_e2e.sh
@@ -4,8 +4,10 @@ set -eo pipefail
 run-e2e() {
   local default_env_file="${1}"
 
+  # begin helmc-remove
   export WORKFLOW_CHART="workflow-${RELEASE}"
   export WORKFLOW_E2E_CHART="workflow-${RELEASE}-e2e"
+  # end helmc-remove
 
   export CLI_VERSION="${CLI_VERSION:-latest}"
   if [ -n "${WORKFLOW_CLI_SHA}" ]; then

--- a/bash/scripts/setup_helmc_environment.sh
+++ b/bash/scripts/setup_helmc_environment.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
+# helmc-remove (entire file)
 setup-helmc-env() {
   if [ -n "${CHARTS_SHA}" ]; then
     helmc_remote_repo="$(get-remote-repo-url charts "${CHARTS_SHA}")"

--- a/bash/tests/setup_helmc_environment_test.bats
+++ b/bash/tests/setup_helmc_environment_test.bats
@@ -1,5 +1,6 @@
 #!/usr/bin/env bats
 
+# helmc-remove (entire file)
 setup() {
   . "${BATS_TEST_DIRNAME}/../scripts/setup_helmc_environment.sh"
   load stub

--- a/common.groovy
+++ b/common.groovy
@@ -33,9 +33,9 @@ defaults = [
     webhookURL: 'a53b3a9e-d649-4cff-9997-6c24f07743c8',
   ],
   helm: [
-    remoteRepo: 'https://github.com/deis/charts.git',
-    remoteBranch: 'master',
-    remoteName: 'deis',
+    remoteRepo: 'https://github.com/deis/charts.git', // helmc-remove
+    remoteBranch: 'master', // helmc-remove
+    remoteName: 'deis', // helmc-remove
     version: 'v2.0.0',
   ],
   github: [

--- a/jobs/apptypes_test.groovy
+++ b/jobs/apptypes_test.groovy
@@ -24,7 +24,7 @@ job(name) {
 
   parameters {
     stringParam('RELEASE', "dev", "Release string for resolving workflow-[release](-e2e) charts")
-    stringParam('HELM_REMOTE_REPO', defaults.helm["remoteRepo"], "The remote repo to use for fetching charts.")
+    stringParam('HELM_REMOTE_REPO', defaults.helm["remoteRepo"], "The remote repo to use for fetching charts.") // helmc-remove
     stringParam('E2E_RUNNER_IMAGE', 'quay.io/deisci/e2e-runner:canary', "The e2e-runner image")
     stringParam('E2E_DIR', '/home/jenkins/workspace/$JOB_NAME/$BUILD_NUMBER', "Directory for storing workspace files")
     stringParam('E2E_DIR_LOGS', '${E2E_DIR}/logs', "Directory for storing logs. This directory is mounted into the e2e-runner container")

--- a/jobs/storage_test.groovy
+++ b/jobs/storage_test.groovy
@@ -24,7 +24,7 @@ job(name) {
 
   parameters {
    stringParam('STORAGE_TYPE', 'gcs', "storage backend for helm chart, default is gcs")
-   stringParam('HELM_REMOTE_REPO', defaults.helm["remoteRepo"], "The remote repo to use for fetching charts.")
+   stringParam('HELM_REMOTE_REPO', defaults.helm["remoteRepo"], "The remote repo to use for fetching charts.") // helmc-remove
    stringParam('E2E_RUNNER_IMAGE', 'quay.io/deisci/e2e-runner:canary', "The e2e-runner image")
    stringParam('E2E_DIR', '/home/jenkins/workspace/$JOB_NAME/$BUILD_NUMBER', "Directory for storing workspace files")
    stringParam('E2E_DIR_LOGS', '${E2E_DIR}/logs', "Directory for storing logs. This directory is mounted into the e2e-runner container")

--- a/jobs/workflow_chart_pipeline.groovy
+++ b/jobs/workflow_chart_pipeline.groovy
@@ -192,7 +192,7 @@ job("${chartRepo.staging}-chart-e2e") {
     stringParam('WORKFLOW_TAG', defaults.workflow.release, 'Workflow chart docker tag')
     stringParam('WORKFLOW_E2E_TAG', '', 'Workflow-E2E chart docker tag')
     stringParam('HELM_VERSION', defaults.helm.version, 'Version of Helm to download/use')
-    booleanParam('USE_KUBERNETES_HELM', true, 'Flag to use kubernetes/helm (Default: true)')
+    booleanParam('USE_HELM_CLASSIC', false, 'Flag to use Helm Classic (Default: false)') // helmc-remove
     stringParam('GINKGO_NODES', '15', "Number of parallel executors to use when running e2e tests")
     stringParam('E2E_RUNNER_IMAGE', 'quay.io/deisci/e2e-runner:canary', "The e2e-runner image")
     stringParam('E2E_DIR', '/home/jenkins/workspace/$JOB_NAME/$BUILD_NUMBER', "Directory for storing workspace files")

--- a/jobs/workflow_test.groovy
+++ b/jobs/workflow_test.groovy
@@ -103,7 +103,7 @@ evaluate(new File("${workspace}/common.groovy"))
       stringParam('COMMIT_AUTHOR_EMAIL', '', "Commit author email address")
       stringParam('CLUSTER_REGEX', '', 'K8s cluster regex (name) to supply when requesting cluster')
       stringParam('CLUSTER_VERSION', '', 'K8s cluster version to supply when requesting cluster')
-      booleanParam('USE_KUBERNETES_HELM', false, 'Flag to use kubernetes/helm (Default: false)')
+      booleanParam('USE_HELM_CLASSIC', false, 'Flag to use Helm Classic (Default: false)') // helmc-remove
     }
 
     triggers {
@@ -142,6 +142,7 @@ evaluate(new File("${workspace}/common.groovy"))
             fi
           """.stripIndent().trim()
 
+        // helmc-remove
         shell new File("${workspace}/bash/scripts/setup_helmc_environment.sh").text +
           """
             mkdir -p ${defaults.tmpPath}

--- a/jobs/workflow_test_release.groovy
+++ b/jobs/workflow_test_release.groovy
@@ -64,7 +64,7 @@ job(name) {
     stringParam('WORKFLOW_BRANCH', "release-${defaults.workflow.release}", "The branch to use for installing the workflow chart.")
     stringParam('WORKFLOW_E2E_BRANCH', "release-${defaults.workflow.release}", "The branch to use for installing the workflow-e2e chart.")
     stringParam('RELEASE', defaults.workflow.release, "Release string for resolving workflow-[release](-e2e) charts")
-    stringParam('HELM_REMOTE_REPO', defaults.helm["remoteRepo"], "The remote repo to use for fetching charts.")
+    stringParam('HELM_REMOTE_REPO', defaults.helm["remoteRepo"], "The remote repo to use for fetching charts.") // helmc-remove
     stringParam('E2E_RUNNER_IMAGE', 'quay.io/deisci/e2e-runner:canary', "The e2e-runner image")
     stringParam('E2E_DIR', '/home/jenkins/workspace/$JOB_NAME/$BUILD_NUMBER', "Directory for storing workspace files")
     stringParam('E2E_DIR_LOGS', '${E2E_DIR}/logs', "Directory for storing logs. This directory is mounted into the e2e-runner container")


### PR DESCRIPTION
Label all helmc-related code with `helmc-remove` designating it for removal
once support is deprecated.

ref https://github.com/deis/e2e-runner/pull/66 (this PR needs to be merged first)