### PR TITLE
fix(bash/scripts/run_e2e.sh): wrap logic in RELEASE check

### DIFF
--- a/bash/scripts/run_e2e.sh
+++ b/bash/scripts/run_e2e.sh
@@ -5,8 +5,10 @@ run-e2e() {
   local default_env_file="${1}"
 
   # begin helmc-remove
-  export WORKFLOW_CHART="workflow-${RELEASE}"
-  export WORKFLOW_E2E_CHART="workflow-${RELEASE}-e2e"
+  if [ -n "${RELEASE}" ]; then
+    export WORKFLOW_CHART="workflow-${RELEASE}"
+    export WORKFLOW_E2E_CHART="workflow-${RELEASE}-e2e"
+  fi
   # end helmc-remove
 
   export CLI_VERSION="${CLI_VERSION:-latest}"

--- a/jobs/workflow_test.groovy
+++ b/jobs/workflow_test.groovy
@@ -96,7 +96,7 @@ evaluate(new File("${workspace}/common.groovy"))
       stringParam('COMPONENT_REPO', '', "Component repo name")
       stringParam('ACTUAL_COMMIT', '', "Component commit SHA")
       stringParam('GINKGO_NODES', '15', "Number of parallel executors to use when running e2e tests")
-      stringParam('RELEASE', 'dev', "Release string for resolving workflow-[release](-e2e) charts")
+      stringParam('RELEASE', 'dev', "Release string for resolving workflow-[release](-e2e) charts") // helmc-remove
       stringParam('E2E_RUNNER_IMAGE', 'quay.io/deisci/e2e-runner:canary', "The e2e-runner image")
       stringParam('E2E_DIR', '/home/jenkins/workspace/$JOB_NAME/$BUILD_NUMBER', "Directory for storing workspace files")
       stringParam('E2E_DIR_LOGS', '${E2E_DIR}/logs', "Directory for storing logs. This directory is mounted into the e2e-runner container")


### PR DESCRIPTION
(logic for soon-to-be-deprecated use of helm-classic)