### PR TITLE
fix(bash/scripts/publish_helm_chart.sh): add cache control

### DIFF
--- a/bash/scripts/publish_helm_chart.sh
+++ b/bash/scripts/publish_helm_chart.sh
@@ -40,7 +40,7 @@ publish-helm-chart() {
 
     # push packaged chart and updated index file to aws s3 bucket
     aws s3 cp "${chart}-${chart_version}".tgz "${DEIS_CHARTS_BUCKET_BASE_URL}/${chart_repo}"/ \
-      && aws s3 cp index.yaml "${DEIS_CHARTS_BUCKET_BASE_URL}/${chart_repo}"/index.yaml \
+      && aws s3 cp --cache-control max_age=0 index.yaml "${DEIS_CHARTS_BUCKET_BASE_URL}/${chart_repo}"/index.yaml \
       && aws s3 cp "${chart}"/values.yaml "${DEIS_CHARTS_BUCKET_BASE_URL}/${chart_repo}/values-${chart_version}".yaml
   else
     echo "No 'charts' directory found at project level; nothing to publish."


### PR DESCRIPTION
Specifically, disable caching for the `index.yaml` file for a given chart.  

This is most needed if the repo type is `dev` or `pr` wherein the file may be updated fairly regularly (certainly in spans less than the default 24 hr caching window).

cc @kmala 