### PR TITLE
chore(common): bump helm version to v2.1.3

### DIFF
--- a/common.groovy
+++ b/common.groovy
@@ -29,7 +29,7 @@ defaults = [
     remoteRepo: 'https://github.com/deis/charts.git', // helmc-remove
     remoteBranch: 'master', // helmc-remove
     remoteName: 'deis', // helmc-remove
-    version: 'v2.1.0',
+    version: 'v2.1.3',
     useClassic: false, // helmc-remove
   ],
   github: [


### PR DESCRIPTION
v2.1.3 of `helm` contains some fixes relevant to Workflow migration, and other improvements.