### PR TITLE
fix(build_darwin_cli_binary.sh): add /usr/local/bin to path

### DIFF
--- a/bash/scripts/build_darwin_cli_binary.sh
+++ b/bash/scripts/build_darwin_cli_binary.sh
@@ -9,7 +9,7 @@ build-darwin-cli-binary() {
 
   # set up go/docker env
   export GOPATH="${WORKSPACE}/golang"
-  export PATH=$PATH:$GOPATH/bin
+  export PATH=$GOPATH/bin:/usr/local/bin:$PATH
   eval "$(docker-machine env default)"
 
   # clean workspace and bootstrap


### PR DESCRIPTION
as it appears it no longer is part of PATH by default

(this is where docker-machine/glide/vboxmanage/etc. are set up)