### PR TITLE
feat(workflow_chart_pipeline.groovy): add githubPush trigger

### DIFF
--- a/jobs/workflow_chart_pipeline.groovy
+++ b/jobs/workflow_chart_pipeline.groovy
@@ -19,6 +19,10 @@ job("${chart}-chart-publish") {
     }
   }
 
+  triggers {
+    githubPush()
+  }
+
   concurrentBuild()
   throttleConcurrentBuilds {
     maxTotal(defaults.maxTotalConcurrentBuilds)


### PR DESCRIPTION
So the default `workflow-chart-publish` job that packages/publishes the latest workflow dev chart will be run on any push to master. 