### PR TITLE
fix(bash/scripts/run_e2e.sh): remove quotes

### DIFF
--- a/bash/scripts/run_e2e.sh
+++ b/bash/scripts/run_e2e.sh
@@ -23,8 +23,9 @@ run-e2e() {
   fi
 
   docker pull "${image}" # bust the cache as tag may be canary
+  # shellcheck disable=SC2086
   docker run \
     -u jenkins:jenkins \
     --env-file="${E2E_DIR}"/env.file \
-    -v "${E2E_DIR_LOGS}":/home/jenkins/logs:rw "${image}" "${docker_run_args}"
+    -v "${E2E_DIR_LOGS}":/home/jenkins/logs:rw "${image}" ${docker_run_args}
 }


### PR DESCRIPTION
The double quotes around `${docker_run_args}` appear to persist if that var is empty;
removing them so `""` is not interpreted as an executable name for the docker run command.