### PR TITLE
chore(common.groovy): bump helm to v2.2.1

### DIFF
--- a/common.groovy
+++ b/common.groovy
@@ -26,7 +26,7 @@ defaults = [
     webhookURL: 'a53b3a9e-d649-4cff-9997-6c24f07743c8',
   ],
   helm: [
-    version: 'v2.1.3',
+    version: 'v2.2.1',
   ],
   github: [
     username: 'deis-admin',


### PR DESCRIPTION
See https://github.com/kubernetes/helm/releases/tag/v2.2.1

Replaces #332.