### PR TITLE
fix(component_jobs.groovy): use 'dev' repo for non-chart PRs

### DIFF
--- a/jobs/component_jobs.groovy
+++ b/jobs/component_jobs.groovy
@@ -206,7 +206,7 @@ repos.each { Map repo ->
                       predefinedProps([
                         'UPSTREAM_BUILD_URL': '${BUILD_URL}',
                         'COMPONENT_REPO': repo.name,
-                        'CHART_REPO_TYPE': chartRepoType,
+                        'CHART_REPO_TYPE': 'dev', // ensure downstream test job installs Workflow from 'dev' repo instead of 'pr' (which may have broken chart)
                       ])
                     }
                   }


### PR DESCRIPTION
So that downstream test job does not install Workflow from 'pr' repo,
which may be a broken chart.