### PR TITLE
fix(get_merge_commit_changes.sh): support non-merge commits

### DIFF
--- a/bash/scripts/get_merge_commit_changes.sh
+++ b/bash/scripts/get_merge_commit_changes.sh
@@ -8,7 +8,12 @@ get-merge-commit-changes() {
   # Grab 'Merge: abc1234 def5678' and convert to abc1234..def5678
   child_commit_range="$(git show "${merge_commit}" | grep 'Merge:' | cut -c8- | sed 's/ /../g')"
 
-  echo "Returning changes from merge commit '${merge_commit}' using the commit range: ${child_commit_range}" >&2
+  if [ "${child_commit_range}" == "" ]; then
+    # commit isn't a merge commit; just use 'merge_commit' directly
+    child_commit_range="${merge_commit}"
+  fi
+
+  echo "Returning changes from commit '${merge_commit}' using the commit range: ${child_commit_range}" >&2
 
   git diff-tree --no-commit-id --name-only -r "${child_commit_range}"
 }

--- a/bash/tests/get_merge_commit_changes_test.bats
+++ b/bash/tests/get_merge_commit_changes_test.bats
@@ -16,6 +16,16 @@ teardown() {
   run get-merge-commit-changes 'foo1234'
 
   [ "${status}" -eq 0 ]
-  [ "${lines[0]}" == "Returning changes from merge commit 'foo1234' using the commit range: abc1234..def5678" ]
+  [ "${lines[0]}" == "Returning changes from commit 'foo1234' using the commit range: abc1234..def5678" ]
   [ "${lines[1]}" == "Merge: abc1234 def5678" ]
+}
+
+@test "get-merge-commit-changes : non-merge commit" {
+  stub git "echo 'foo'"
+
+  run get-merge-commit-changes 'foo1234'
+
+  [ "${status}" -eq 0 ]
+  [ "${lines[0]}" == "Returning changes from commit 'foo1234' using the commit range: foo1234" ]
+  [ "${lines[1]}" == "foo" ]
 }


### PR DESCRIPTION
Especially necessary when a job is kicked off manually with a specific, non-merge commit sha