### PR TITLE
fix(jobs/storage_test.groovy): add HELM_VERSION param

### DIFF
--- a/jobs/storage_test.groovy
+++ b/jobs/storage_test.groovy
@@ -30,6 +30,7 @@ job(name) {
 
   parameters {
    choiceParam('STORAGE_TYPE', ['gcs', 's3'], "storage backend for helm chart, default is gcs")
+   stringParam('HELM_VERSION', defaults.helm.version, 'Version of Helm to download/use')
    stringParam('E2E_RUNNER_IMAGE', 'quay.io/deisci/e2e-runner:canary', "The e2e-runner image")
    stringParam('E2E_DIR', '/home/jenkins/workspace/$JOB_NAME/$BUILD_NUMBER', "Directory for storing workspace files")
    stringParam('E2E_DIR_LOGS', '${E2E_DIR}/logs', "Directory for storing logs. This directory is mounted into the e2e-runner container")


### PR DESCRIPTION
So we can pin helm to latest stable/supported release