### PR TITLE
fix(jobs/component_jobs.groovy): specify publish job NODE

### DIFF
--- a/jobs/component_jobs.groovy
+++ b/jobs/component_jobs.groovy
@@ -178,7 +178,10 @@ repos.each { Map repo ->
                     }
                     parameters {
                       propertiesFile(defaults.envFile)
-                      predefinedProps(['CHART_REPO_TYPE': chartRepoType])
+                      predefinedProps([
+                        'CHART_REPO_TYPE': chartRepoType,
+                        'NODE': 'linux',
+                      ])
                     }
                   }
                 }


### PR DESCRIPTION
I didn't think we needed to specify (downstream job use its defaults) but had been getting errors saying it was triggered without specifying... so... here we go.