### PR TITLE
ref(jobs): clean workspace before build

### DIFF
--- a/jobs/component_chart_publish.groovy
+++ b/jobs/component_chart_publish.groovy
@@ -21,8 +21,6 @@ repos.each { Map repo ->
       }
 
       publishers {
-        wsCleanup() // Scrub workspace clean after build
-
         def statusesToNotify = [['SUCCESS', 'success'],['FAILURE', 'failure'],['ABORTED', 'error'],['UNSTABLE', 'failure']]
         postBuildScripts {
           onlyIfBuildSucceeds(false)
@@ -77,6 +75,8 @@ repos.each { Map repo ->
       }
 
       wrappers {
+        preBuildCleanup() // Scrub workspace clean before build
+
         buildName('${RELEASE_TAG} ${CHART_REPO_TYPE} #${BUILD_NUMBER}')
         timestamps()
         colorizeOutput 'xterm'

--- a/jobs/helm_chart_verify.groovy
+++ b/jobs/helm_chart_verify.groovy
@@ -6,8 +6,6 @@ job("helm-chart-verify") {
   description "Verifies a signed Deis Helm chart"
 
   publishers {
-    wsCleanup() // Scrub workspace clean after build
-
     postBuildScripts {
       onlyIfBuildSucceeds(false)
       steps {
@@ -39,6 +37,8 @@ job("helm-chart-verify") {
   }
 
   wrappers {
+    preBuildCleanup() // Scrub workspace clean before build
+
     buildName('${CHART} ${RELEASE_TAG} #${BUILD_NUMBER}')
     timestamps()
     colorizeOutput 'xterm'

--- a/jobs/workflow_chart_pipeline.groovy
+++ b/jobs/workflow_chart_pipeline.groovy
@@ -29,8 +29,6 @@ job("${chart}-chart-publish") {
   }
 
   publishers {
-    wsCleanup() // Scrub workspace clean after build
-
     def statusesToNotify = [['SUCCESS', 'success'],['FAILURE', 'failure'],['ABORTED', 'error'],['UNSTABLE', 'failure']]
     postBuildScripts {
       onlyIfBuildSucceeds(false)
@@ -81,6 +79,8 @@ job("${chart}-chart-publish") {
   }
 
   wrappers {
+    preBuildCleanup() // Scrub workspace clean before build
+
     buildName('${COMPONENT_REPO} ${CHART_REPO_TYPE} #${BUILD_NUMBER}')
     timestamps()
     colorizeOutput 'xterm'
@@ -278,8 +278,6 @@ job("${chart}-chart-stage") {
   }
 
   publishers {
-    wsCleanup() // Scrub workspace clean after build
-
     postBuildScripts {
       onlyIfBuildSucceeds(false)
       steps {
@@ -313,6 +311,8 @@ job("${chart}-chart-stage") {
   }
 
   wrappers {
+    preBuildCleanup() // Scrub workspace clean before build
+
     buildName('${RELEASE_TAG} #${BUILD_NUMBER}')
     timestamps()
     colorizeOutput 'xterm'
@@ -365,8 +365,6 @@ job("${chart}-chart-release") {
   }
 
   publishers {
-    wsCleanup() // Scrub workspace clean after build
-
     postBuildScripts {
       onlyIfBuildSucceeds(false)
       steps {
@@ -391,6 +389,8 @@ job("${chart}-chart-release") {
   }
 
   wrappers {
+    preBuildCleanup() // Scrub workspace clean before build
+
     buildName('${RELEASE_TAG} #${BUILD_NUMBER}')
     timestamps()
     colorizeOutput 'xterm'


### PR DESCRIPTION
Now that we use dynamic agents as default, it seems the agent pods would already be torn down by the time jobs attempted to clean the workspace after the build.  Therefore, changing up to clean workspace prior...

It is meant to avoid the following:
<img width="1295" alt="ws-cleanup warnings" src="https://cloud.githubusercontent.com/assets/9322017/25026201/abb5b348-2062-11e7-904c-dd4fac31dc62.png">
