### PR TITLE
feat(repo.groovy): Remove influxdb from component list

### DIFF
--- a/repo.groovy
+++ b/repo.groovy
@@ -61,7 +61,7 @@ repos = [
     chart: 'minio'],
 
   [ name: 'monitor',
-    components: [[name: 'grafana'], [name: 'influxdb'], [name: 'telegraf']],
+    components: [[name: 'grafana'], [name: 'telegraf']],
     slackChannel: '#monitor',
     runE2e: false,
     workflowComponent: true,


### PR DESCRIPTION
Because we are no longer actively maintaining an influxdb setup for the monitoring stack we should not have any jobs run for it.

depends on https://github.com/deis/monitor/pull/185