### PR TITLE
chore(common.groovy): bump helm to 2.3.1

### DIFF
--- a/common.groovy
+++ b/common.groovy
@@ -23,7 +23,7 @@ defaults = [
     webhookURL: 'a53b3a9e-d649-4cff-9997-6c24f07743c8',
   ],
   helm: [
-    version: 'v2.3.0',
+    version: 'v2.3.1',
   ],
   github: [
     username: 'deis-admin',


### PR DESCRIPTION
See https://github.com/kubernetes/helm/releases/tag/v2.3.1