### PR TITLE
fix(jobs/component_release.groovy): check if tag already released

### DIFF
--- a/bash/scripts/get_latest_tag.sh
+++ b/bash/scripts/get_latest_tag.sh
@@ -3,6 +3,8 @@
 set -eo pipefail
 
 get-latest-tag() {
+  component="${1}"
+
   tag=''
   if [ -n "${TAG}" ]; then
     tag="${TAG}"
@@ -11,5 +13,12 @@ get-latest-tag() {
   else
     exit 1
   fi
+
+  # If tag already released, bail out
+  if curl -sSf "https://versions.deis.com/v3/versions/stable/deis-${component}/${tag}"; then
+    echo "Silly Jenkins, ${component} tag '${tag}' has already been released!  Exiting." >&2
+    exit 1
+  fi
+
   echo "${tag}"
 }

--- a/bash/tests/get_latest_tag_test.bats
+++ b/bash/tests/get_latest_tag_test.bats
@@ -4,6 +4,7 @@ setup() {
   . "${BATS_TEST_DIRNAME}/../scripts/get_latest_tag.sh"
   load stub
   stub docker
+  stub curl "" 1 # curl for if component released fails (component not released)
 }
 
 teardown() {
@@ -35,4 +36,15 @@ teardown() {
 
   [ "${status}" -eq 0 ]
   [ "${output}" == "${TAG}" ]
+}
+
+@test "main : component already released" {
+  export TAG="foo-tag"
+
+  stub curl "" 0
+
+  run get-latest-tag foo
+
+  [ "${status}" -eq 1 ]
+  [ "${output}" == "Silly Jenkins, foo tag '${TAG}' has already been released!  Exiting." ]
 }

--- a/jobs/component_release.groovy
+++ b/jobs/component_release.groovy
@@ -81,7 +81,7 @@ repos.each { Map repo ->
 
             set -eo pipefail
 
-            tag="\$(get-latest-tag)"
+            tag="\$(get-latest-tag ${component.name})"
             commit="\$(git checkout "\${tag}" && git rev-parse HEAD)"
             echo "Checked out tag '\${tag}' and will pass commit at HEAD (\${commit}) to downstream job."
 

--- a/jobs/workflow_cli_release.groovy
+++ b/jobs/workflow_cli_release.groovy
@@ -84,7 +84,9 @@ job("${repoName}-release") {
     shell new File("${workspace}/bash/scripts/get_latest_tag.sh").text +
       """
         mkdir -p ${defaults.tmpPath}
-        echo TAG="\$(get-latest-tag)" > ${defaults.envFile}
+        tag="\$(get-latest-tag ${repoName})"
+
+        echo TAG="\${tag}" > ${defaults.envFile}
       """.stripIndent().trim()
 
     downstreamParameterized {


### PR DESCRIPTION
Jenkins has a bizarre quirk of sometimes attempting to release a given tag multiple times, having been incorrectly triggered by other push events.  Until we figure out the root cause, this quick check avoids attempting an subsequent releases of a tag.