### PR TITLE
fix(bash/scripts/get_latest_tag.sh): check GH for released tags

### DIFF
--- a/bash/scripts/get_latest_tag.sh
+++ b/bash/scripts/get_latest_tag.sh
@@ -14,8 +14,11 @@ get-latest-tag() {
     exit 1
   fi
 
+  # grab all released tags from GH
+  released_tags="$(curl -sSf "https://api.github.com/repos/deis/${component}/releases" | jq '.[].tag_name')"
+
   # If tag already released, bail out
-  if curl -sSf "https://versions.deis.com/v3/versions/stable/deis-${component}/${tag}"; then
+  if [[ "${released_tags}" == *"${tag}"* ]]; then
     echo "Silly Jenkins, ${component} tag '${tag}' has already been released!  Exiting." >&2
     exit 1
   fi

--- a/bash/tests/get_latest_tag_test.bats
+++ b/bash/tests/get_latest_tag_test.bats
@@ -4,7 +4,8 @@ setup() {
   . "${BATS_TEST_DIRNAME}/../scripts/get_latest_tag.sh"
   load stub
   stub docker
-  stub curl "" 1 # curl for if component released fails (component not released)
+  stub curl
+  stub jq
 }
 
 teardown() {
@@ -41,7 +42,7 @@ teardown() {
 @test "main : component already released" {
   export TAG="foo-tag"
 
-  stub curl "" 0
+  stub jq "echo 'foo-tag bar-tag'" 0
 
   run get-latest-tag foo
 


### PR DESCRIPTION
Check GH for releases as some repos (`workflow-cli`) are not reported to `versions.deis.com`