### PR TITLE
feat(jobs/*): Adds cloud provider env var to e2e jobs

### DIFF
--- a/common.groovy
+++ b/common.groovy
@@ -34,6 +34,7 @@ defaults = [
     storageAccountKeyID: 'c9cad0b0-53dd-4d38-a832-c4b29aeaf49b',
   ],
   statusesToNotify: ['SUCCESS', 'FAILURE'],
+  "e2eRunner": [ provider: 'azure', ],
 ]
 
 e2eRunnerJob = new File("${workspace}/bash/scripts/run_e2e.sh").text +

--- a/jobs/apptypes_test.groovy
+++ b/jobs/apptypes_test.groovy
@@ -38,6 +38,7 @@ job(name) {
     colorizeOutput 'xterm'
     credentialsBinding {
       string("AUTH_TOKEN", "a62d7fe9-5b74-47e3-9aa5-2458ba32da52")
+      string("CLOUD_PROVIDER", defaults.e2eRunner.provider)
     }
   }
 

--- a/jobs/storage_test.groovy
+++ b/jobs/storage_test.groovy
@@ -108,6 +108,7 @@ job(name) {
       string("AWS_ACCESS_KEY_ID","02a5c84e-3248-4776-acc5-6b6a1fb24dfc")
       // k8s-claimer auth
       string("AUTH_TOKEN", "a62d7fe9-5b74-47e3-9aa5-2458ba32da52")
+      string("CLOUD_PROVIDER", defaults.e2eRunner.provider)
     }
   }
 

--- a/jobs/workflow_chart_pipeline.groovy
+++ b/jobs/workflow_chart_pipeline.groovy
@@ -236,6 +236,7 @@ job("${chart}-chart-e2e") {
       string("AUTH_TOKEN", "a62d7fe9-5b74-47e3-9aa5-2458ba32da52")
       string("GITHUB_ACCESS_TOKEN", defaults.github.credentialsID)
       string("SLACK_INCOMING_WEBHOOK_URL", defaults.slack.webhookURL)
+      string("CLOUD_PROVIDER", defaults.e2eRunner.provider)
     }
   }
 

--- a/jobs/workflow_upgrade_test.groovy
+++ b/jobs/workflow_upgrade_test.groovy
@@ -83,6 +83,7 @@ job("${chart}-upgrade-test") {
       string("SLACK_INCOMING_WEBHOOK_URL", defaults.slack.webhookURL)
       // k8s-claimer auth
       string("AUTH_TOKEN", "a62d7fe9-5b74-47e3-9aa5-2458ba32da52")
+      string("CLOUD_PROVIDER", defaults.e2eRunner.provider)
 
       // Off-cluster storage support
       // gcloud/gsutil


### PR DESCRIPTION
This will be defaulted to google for now