### PR TITLE
feat(k8s-claimer): Use charts to deploy instead of workflow

### DIFF
--- a/jobs/k8s_claimer.groovy
+++ b/jobs/k8s_claimer.groovy
@@ -4,6 +4,116 @@ evaluate(new File("${workspace}/common.groovy"))
 
 slackChannel = '#ops'
 
+job('k8s-claimer-pr') {
+  description """
+  <p>Run the tests for k8s-claimer</p>
+  <p>
+    K8s-Claimer serves as a Kubernetes cluster leaser for running Workflow E2E tests in CI.
+  </p>
+  """.stripIndent().trim()
+
+  scm {
+    git {
+      remote {
+        github("deis/k8s-claimer")
+        credentials('597819a0-b0b9-4974-a79b-3a5c2322606d')
+        refspec('+refs/pull/*:refs/remotes/origin/pr/*')
+      }
+      branch('${sha1}')
+    }
+  }
+
+  def statusesToNotify = ['FAILURE']
+  publishers {
+    postBuildScripts {
+      onlyIfBuildSucceeds(false)
+      steps {
+        statusesToNotify.each { buildStatus ->
+          conditionalSteps {
+            condition {
+              status(buildStatus, buildStatus)
+              steps {
+                shell new File("${workspace}/bash/scripts/slack_notify.sh").text +
+                  """
+                    slack-notify "${slackChannel}" "${buildStatus}"
+                  """.stripIndent().trim()
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  concurrentBuild()
+  throttleConcurrentBuilds {
+    maxPerNode(defaults.maxBuildsPerNode)
+    maxTotal(defaults.maxTotalConcurrentBuilds)
+  }
+
+  logRotator {
+    daysToKeep defaults.daysToKeep
+  }
+
+  triggers {
+    pullRequest {
+      admin('deis-admin')
+      cron('H/5 * * * *')
+      useGitHubHooks()
+      triggerPhrase('OK to test')
+      orgWhitelist(['deis'])
+      allowMembersOfWhitelistedOrgsAsAdmin()
+      // this plugin will update PR status no matter what,
+      // so until we fix this, here are our default messages:
+      extensions {
+        commitStatus {
+          context('ci/jenkins/pr')
+          triggeredStatus("Triggering k8s-claimer build/test pipeline...")
+          startedStatus("Starting k8s-claimer build/test pipeline...")
+          completedStatus('SUCCESS', "k8s-claimer build/test pipeline SUCCESS!")
+          completedStatus('FAILURE', "k8s-claimer build/test pipeline FAILURE.")
+          completedStatus('ERROR', 'Something went wrong.')
+        }
+      }
+    }
+  }
+
+  parameters {
+    stringParam('DOCKER_USERNAME', 'deisbot', 'Docker Hub account name')
+    stringParam('DOCKER_EMAIL', 'dummy-address@deis.com', 'Docker Hub email address')
+    stringParam('QUAY_USERNAME', 'deisci+jenkins', 'Quay account name')
+    stringParam('QUAY_EMAIL', 'deisci+jenkins@deis.com', 'Quay email address')
+    stringParam('sha1', 'master', 'Specific Git SHA to test')
+  }
+
+  triggers {
+    githubPush()
+  }
+
+  wrappers {
+    timestamps()
+    colorizeOutput 'xterm'
+    credentialsBinding {
+      string("GITHUB_ACCESS_TOKEN", defaults.github.credentialsID)
+      string("SLACK_INCOMING_WEBHOOK_URL", defaults.slack.webhookURL)
+      string("CODECOV_TOKEN", "c5689e5d-61d2-4556-9333-c1e668516c1e")
+    }
+  }
+
+  steps {
+    main = [
+      new File("${workspace}/bash/scripts/get_actual_commit.sh").text,
+      new File("${workspace}/bash/scripts/find_required_commits.sh").text,
+    ].join('\n')
+
+    shell """
+      #!/usr/bin/env bash
+      set -eo pipefail
+      make bootstrap test-cover build-cli build || true
+    """.stripIndent().trim()
+  }  
+}
+
 job('k8s-claimer-build-cli') {
   description """
   <p>Builds the k8s-claimer CLI and uploads to Azure Blob storage </p>
@@ -48,17 +158,13 @@ job('k8s-claimer-build-cli') {
     }
   }
 
-  parameters {
-    stringParam('QUAY_USERNAME', 'deis+jenkins', 'Quay account name')
-    stringParam('QUAY_EMAIL', 'deis+jenkins@deis.com', 'Quay email address')
-  }
 
   wrappers {
     timestamps()
     colorizeOutput 'xterm'
     credentialsBinding {
-      string("AZURE_STORAGE_ACCOUNT", defaults.azure.storageAccount)
-      string("AZURE_STORAGE_KEY", defaults.azure.storageAccountKeyID)
+      string("AZURE_STORAGE_ACCOUNT", "k8sclaimercli")
+      string("AZURE_STORAGE_KEY", "0211420f-1544-4543-b7bf-0c21dddf5db1")
       string("GITHUB_ACCESS_TOKEN", defaults.github.credentialsID)
       string("SLACK_INCOMING_WEBHOOK_URL", defaults.slack.webhookURL)
     }
@@ -69,12 +175,14 @@ job('k8s-claimer-build-cli') {
       #!/usr/bin/env bash
       set -eo pipefail
 
-     make bootstrap build-cli
+      #build the CLI for darwin/linux platforms
+      make bootstrap build-cli-cross
+
+      #upload to azure blob storage
+      az storage blob upload-batch --content-cache-control="max-age=0" -s _dist -d cli
     """.stripIndent().trim()
   }
 }
-
-
 
 job('k8s-claimer-deploy') {
   description """
@@ -156,6 +264,7 @@ job('k8s-claimer-deploy') {
       export DEIS_REGISTRY=quay.io/
       docker login -e="\$QUAY_EMAIL" -u="\$QUAY_USERNAME" -p="\$QUAY_PASSWORD" quay.io
 
+      DOCKER_BUILD_FLAGS="--pull --no-cache" \
       KUBECONFIG=kubeconfig \
       ARGS=config.ssh_key=\${K8S_CLAIMER_SSH_KEY},\
       config.google.account_file=\${GOOGLE_CLOUD_ACCOUNT_FILE},\

--- a/jobs/k8s_claimer_deploy.groovy
+++ b/jobs/k8s_claimer_deploy.groovy
@@ -2,10 +2,81 @@ def workspace = new File(".").getAbsolutePath()
 if (!new File("${workspace}/common.groovy").canRead()) { workspace = "${WORKSPACE}"}
 evaluate(new File("${workspace}/common.groovy"))
 
-name = 'k8s-claimer-deploy'
 slackChannel = '#ops'
 
-job(name) {
+job('k8s-claimer-build-cli') {
+  description """
+  <p>Builds the k8s-claimer CLI and uploads to Azure Blob storage </p>
+  <p>
+    K8s-Claimer serves as a Kubernetes cluster leaser for running Workflow E2E tests in CI.
+  </p>
+  """.stripIndent().trim()
+
+  scm {
+    git {
+      remote {
+        github('deis/k8s-claimer')
+        credentials('597819a0-b0b9-4974-a79b-3a5c2322606d')
+      }
+      branch('master')
+    }
+  }
+
+  logRotator {
+    daysToKeep defaults.daysToKeep
+  }
+
+  publishers {
+    def statusesToNotify = ['SUCCESS', 'FAILURE']
+    postBuildScripts {
+      onlyIfBuildSucceeds(false)
+      steps {
+        statusesToNotify.each { buildStatus ->
+          conditionalSteps {
+            condition {
+             status(buildStatus, buildStatus)
+              steps {
+                shell new File("${workspace}/bash/scripts/slack_notify.sh").text +
+                  """
+                    slack-notify '${slackChannel}' "${buildStatus}"
+                  """.stripIndent().trim()
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  parameters {
+    stringParam('QUAY_USERNAME', 'deis+jenkins', 'Quay account name')
+    stringParam('QUAY_EMAIL', 'deis+jenkins@deis.com', 'Quay email address')
+  }
+
+  wrappers {
+    timestamps()
+    colorizeOutput 'xterm'
+    credentialsBinding {
+      string("AZURE_STORAGE_ACCOUNT", defaults.azure.storageAccount)
+      string("AZURE_STORAGE_KEY", defaults.azure.storageAccountKeyID)
+      string("GITHUB_ACCESS_TOKEN", defaults.github.credentialsID)
+      string("SLACK_INCOMING_WEBHOOK_URL", defaults.slack.webhookURL)
+    }
+  }
+
+  steps {
+    shell """
+      #!/usr/bin/env bash
+      set -eo pipefail
+
+     make bootstrap build-cli
+    """.stripIndent().trim()
+  }
+}
+
+
+
+job('k8s-claimer-deploy') {
   description """
   <p>Compiles and deploys <a href="https://github.com/deis/k8s-claimer">k8s-claimer</a>
     to the Deis Workflow staging cluster.
@@ -60,29 +131,41 @@ job(name) {
     timestamps()
     colorizeOutput 'xterm'
     credentialsBinding {
+      string("KUBECONFIG_BASE64", "aa198b18-3566-438b-bab2-2dd169015567")
+      string("K8S_CLAIMER_SSH_KEY", "394d55f4-b9b6-4913-8b22-e874939f90b4")
+      string("GOOGLE_CLOUD_ACCOUNT_FILE", "ba7ab317-a820-4e70-9399-a54cf3a59949")
+      string("AUTH_TOKEN", "a62d7fe9-5b74-47e3-9aa5-2458ba32da52")
+      string("AZURE_SUBSCRIPTION_ID", "1b2376bb-38ed-480b-8bcc-81250ebaa327")
+      string("AZURE_CLIENT_ID", "862dbc6f-2fbe-4342-a797-c6433efb6761")
+      string("AZURE_CLIENT_SECRET", "3d5c3d60-8648-42f4-8401-7d96e08ca080")
+      string("AZURE_TENANT_ID", "528070f3-4799-4c1a-94d6-20a16177487a")
       string("GITHUB_ACCESS_TOKEN", defaults.github.credentialsID)
       string("SLACK_INCOMING_WEBHOOK_URL", defaults.slack.webhookURL)
       string("QUAY_PASSWORD", "8317a529-10f7-40b5-abd4-a42f242f22f0")
-      string("DEIS_URL", "1a72f795-58c5-4832-a463-28aa2765ba14")
-      string("DEIS_USERNAME", "ed8d00a4-5360-4182-8a86-c9175220296a")
-      string("DEIS_PASSWORD", "82b41d2d-53c6-4e24-bf77-108322ff799a")
     }
   }
 
   steps {
-    shell '''
+    shell """
       #!/usr/bin/env bash
-
       set -eo pipefail
+      echo \$KUBECONFIG_BASE64 | base64 --decode > kubeconfig
+
+      download-and-init-helm
 
       export DEIS_REGISTRY=quay.io/
       docker login -e="\$QUAY_EMAIL" -u="\$QUAY_USERNAME" -p="\$QUAY_PASSWORD" quay.io
-      make bootstrap build docker-build docker-push
 
-      curl -sSL http://deis.io/deis-cli/install-v2.sh | bash
-      export PATH="\$(pwd):\$PATH"
-
-      make deploy
-    '''.stripIndent().trim()
+      KUBECONFIG=kubeconfig \
+      ARGS=config.ssh_key=\${K8S_CLAIMER_SSH_KEY},\
+      config.google.account_file=\${GOOGLE_CLOUD_ACCOUNT_FILE},\
+      config.google.project_id=deis-e2e-leasable,\
+      config.auth_token=\${AUTH_TOKEN},\
+      config.namespace=k8sclaimer,\
+      config.azure.subscription_id=\${AZURE_SUBSCRIPTION_ID},\
+      config.azure.client_id=\${AZURE_CLIENT_ID},\
+      config.azure.client_secret=\${AZURE_CLIENT_SECRET},\
+      config.azure.tenant_id=\${AZURE_TENANT_ID} make bootstrap build push upgrade
+    """.stripIndent().trim()
   }
 }


### PR DESCRIPTION
This PR does a number of things

* Use the k8sclaimer chart to deploy instead of workflow
* Creates a master build cli job and uploads to azure blob storage
* Creates a PR job for running tests, building the cli, and building the binary/image. It will not upload the artifacts or the image to quay!