### PR TITLE
fix(bash/scripts/git_latest_tag.sh): check latest tag

### DIFF
--- a/bash/scripts/get_latest_tag.sh
+++ b/bash/scripts/get_latest_tag.sh
@@ -14,11 +14,11 @@ get-latest-tag() {
     exit 1
   fi
 
-  # grab all released tags from GH
-  released_tags="$(curl -sSf "https://api.github.com/repos/deis/${component}/releases" | jq '.[].tag_name')"
+  # grab latest tag from GH
+  latest_tag="$(curl -sSf "https://api.github.com/repos/deis/${component}/releases/latest" | jq '.tag_name' | tr -d '"')"
 
-  # If tag already released, bail out
-  if [[ "${released_tags}" == *"${tag}"* ]]; then
+  # If tag not latest, bail out
+  if [ "${tag}" != "${latest_tag}" ]; then
     echo "Silly Jenkins, ${component} tag '${tag}' has already been released!  Exiting." >&2
     exit 1
   fi

--- a/bash/tests/get_latest_tag_test.bats
+++ b/bash/tests/get_latest_tag_test.bats
@@ -5,7 +5,7 @@ setup() {
   load stub
   stub docker
   stub curl
-  stub jq
+  stub jq "echo 'foo-tag'" 0
 }
 
 teardown() {
@@ -40,9 +40,7 @@ teardown() {
 }
 
 @test "main : component already released" {
-  export TAG="foo-tag"
-
-  stub jq "echo 'foo-tag bar-tag'" 0
+  export TAG="older-tag"
 
   run get-latest-tag foo
 


### PR DESCRIPTION
Check latest tag from GitHub... if tag intended to be released doesn't match (presumably b/c it's older and/or not valid), bail out.

Better approach to https://github.com/deis/jenkins-jobs/pull/375/files