### PR TITLE
fix(helm_chart_verify): coerce gpg into using old keyring format

### DIFF
--- a/jobs/helm_chart_verify.groovy
+++ b/jobs/helm_chart_verify.groovy
@@ -61,6 +61,10 @@ job("helm-chart-verify") {
         # fetch key from keyserver
         gpg --keyserver pgp.mit.edu --recv-keys 1D6A97D0
 
+        # coerce gpg into old keyring format
+        mkdir -p "${HOME}/.gnupg"
+        touch "${HOME}/.gnupg/pubring.gpg"
+
         helm repo add "${CHART}" https://charts.deis.com/"${CHART_REPO}"
         helm fetch --verify "${CHART_REPO}"/"${CHART}" --version "${RELEASE_TAG}"
       '''.stripIndent().trim()


### PR DESCRIPTION
This avoids
```
Error: failed to load keyring: open /home/jenkins/.gnupg/pubring.gpg: no such file or directory
```
See https://www.gnupg.org/faq/whats-new-in-2.1.html for an explanation of why the presence of pubring.gpg changes GPG's behavior to be more compatible with helm.

I've been testing this live on Jenkins and can confirm it fixes some of the `helm-chart-verify` job issue. The rest of the fix is in deis/jenkins-node#21.